### PR TITLE
Add "Return YouTube Dislike" support and add video information to TV UI

### DIFF
--- a/lib/controllers/settingsController.dart
+++ b/lib/controllers/settingsController.dart
@@ -27,6 +27,7 @@ class SettingsController extends GetxController {
   bool useDynamicTheme = db.getSettings(DYNAMIC_THEME)?.value == 'true';
   bool useDash = db.getSettings(USE_DASH)?.value == 'true';
   bool useProxy = db.getSettings(USE_PROXY)?.value == 'true';
+  bool useReturnYoutubeDislike = db.getSettings(USE_RETURN_YOUTUBE_DISLIKE)?.value == 'true';
   bool blackBackground = db.getSettings(BLACK_BACKGROUND)?.value == 'true';
   double subtitleSize = double.parse(db.getSettings(SUBTITLE_SIZE)?.value ?? subtitleDefaultSize);
   bool skipSslVerification = db.getSettings(SKIP_SSL_VERIFICATION)?.value == 'true';
@@ -60,6 +61,12 @@ class SettingsController extends GetxController {
   toggleProxy(bool value) {
     db.saveSetting(SettingsValue(USE_PROXY, value.toString()));
     useProxy = value;
+    update();
+  }
+
+  toggleReturnYoutubeDislike(bool value) {
+    db.saveSetting(SettingsValue(USE_RETURN_YOUTUBE_DISLIKE, value.toString()));
+    useReturnYoutubeDislike = value;
     update();
   }
 

--- a/lib/controllers/videoController.dart
+++ b/lib/controllers/videoController.dart
@@ -4,6 +4,7 @@ import 'package:invidious/controllers/videoInnerViewController.dart';
 import 'package:invidious/database.dart';
 import 'package:invidious/models/baseVideo.dart';
 import 'package:invidious/models/db/settings.dart';
+import 'package:invidious/models/dislike.dart';
 import 'package:logging/logging.dart';
 
 import '../globals.dart';
@@ -16,8 +17,10 @@ const String coulnotLoadVideos = 'cannot-load-videos';
 class VideoController extends GetxController {
   final log = Logger('Video');
   Video? video;
+  int dislikes = 0;
   bool loadingVideo = true;
   bool playRecommendedNext = db.getSettings(PLAY_RECOMMENDED_NEXT)?.value == 'true';
+  bool getDislikes = db.getSettings(USE_RETURN_YOUTUBE_DISLIKE)?.value == 'true';
 
   int selectedIndex = 0;
   String videoId;
@@ -36,6 +39,12 @@ class VideoController extends GetxController {
       Video video = await service.getVideo(videoId);
       this.video = video;
       loadingVideo = false;
+
+      if (getDislikes) {
+        Dislike dislike = await service.getDislikes(videoId);
+        dislikes = dislike.dislikes;
+      }
+
       update();
     } catch (err) {
       if (err is InvidiousServiceError) {

--- a/lib/database.dart
+++ b/lib/database.dart
@@ -18,6 +18,7 @@ const PLAYER_REPEAT = 'player-repeat';
 const PLAYER_SHUFFLE = 'player-shuffle';
 const PLAY_RECOMMENDED_NEXT = 'play-recommended-next';
 const USE_PROXY = 'use-proxy';
+const USE_RETURN_YOUTUBE_DISLIKE = 'use-return-youtube-dislike';
 const BLACK_BACKGROUND = 'black-background';
 const SUBTITLE_SIZE = 'subtitles-size';
 const SKIP_SSL_VERIFICATION = 'skip-ssl-verification';

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -558,5 +558,9 @@
                 "format": "compact"
             }
         }
+    },
+    "returnYoutubeDislikeDescription": "Show estimated video dislikes",
+    "@returnYoutubeDislikeDescription": {
+        "description": "ReturnYoutubeDislike setting description"
     }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -559,7 +559,7 @@
             }
         }
     },
-    "returnYoutubeDislikeDescription": "Show estimated video dislikes",
+    "returnYoutubeDislikeDescription": "Show estimated video dislikes using API provided by returnyoutubedislike.com",
     "@returnYoutubeDislikeDescription": {
         "description": "ReturnYoutubeDislike setting description"
     }

--- a/lib/models/dislike.dart
+++ b/lib/models/dislike.dart
@@ -1,0 +1,14 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'dislike.g.dart';
+
+@JsonSerializable()
+class Dislike {
+  int dislikes;
+
+  Dislike(this.dislikes);
+
+  factory Dislike.fromJson(Map<String, dynamic> json) => _$DislikeFromJson(json);
+
+  Map<String, dynamic> toJson() => _$DislikeToJson(this);
+}

--- a/lib/models/dislike.g.dart
+++ b/lib/models/dislike.g.dart
@@ -1,0 +1,15 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'dislike.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Dislike _$DislikeFromJson(Map<String, dynamic> json) => Dislike(
+      json['dislikes'] as int,
+    );
+
+Map<String, dynamic> _$DislikeToJson(Dislike instance) => <String, dynamic>{
+      'dislikes': instance.dislikes,
+    };

--- a/lib/service.dart
+++ b/lib/service.dart
@@ -8,6 +8,7 @@ import 'package:http/http.dart';
 import 'package:http/http.dart' as http;
 import 'package:invidious/database.dart';
 import 'package:invidious/globals.dart';
+import 'package:invidious/models/dislike.dart';
 import 'package:invidious/models/errors/invidiousServiceError.dart';
 import 'package:invidious/models/playlist.dart';
 import 'package:invidious/models/searchResult.dart';
@@ -50,6 +51,7 @@ const POST_USER_PLAYLIST_VIDEO = '/api/v1/auth/playlists/:id/videos';
 const DELETE_USER_PLAYLIST = '/api/v1/auth/playlists/:id';
 const DELETE_USER_PLAYLIST_VIDEO = '/api/v1/auth/playlists/:id/videos/:index';
 const GET_PUBLIC_PLAYLIST = '/api/v1/playlists/:id';
+const GET_DISLIKES = 'https://returnyoutubedislikeapi.com/votes?videoId=';
 
 const MAX_PING = 9007199254740991;
 
@@ -460,5 +462,12 @@ class Service {
 
     final response = await http.get(uri);
     return Playlist.fromJson(handleResponse(response));
+  }
+
+  Future<Dislike> getDislikes(String videoId) async {
+    Uri uri = Uri.parse(GET_DISLIKES + videoId);
+
+    final response = await http.get(uri);
+    return Dislike.fromJson(handleResponse(response));
   }
 }

--- a/lib/views/settings.dart
+++ b/lib/views/settings.dart
@@ -154,7 +154,13 @@ class Settings extends StatelessWidget {
                     title: Text(locals.appLanguage),
                     value: Text('${_.getLocaleDisplayName() ?? locals.followSystem}. ${locals.requiresRestart}'),
                     onPressed: (context) => showSelectLanguage(context, _),
-                  )
+                  ),
+                  SettingsTile.switchTile(
+                    title: const Text('Return YouTube Dislike'),
+                    description: Text(locals.returnYoutubeDislikeDescription),
+                    initialValue: _.useReturnYoutubeDislike,
+                    onToggle: _.toggleReturnYoutubeDislike,
+                  ),
                 ],
               ),
               SettingsSection(title: Text(locals.servers), tiles: [
@@ -199,12 +205,6 @@ class Settings extends StatelessWidget {
                   title: const Text('SponsorBlock'),
                   description: Text(locals.sponsorBlockDescription),
                   onPressed: openSponsorBlockSettings,
-                ),
-                SettingsTile.switchTile(
-                  title: const Text('Return YouTube Dislike'),
-                  description: Text(locals.returnYoutubeDislikeDescription),
-                  initialValue: _.useReturnYoutubeDislike,
-                  onToggle: _.toggleReturnYoutubeDislike,
                 ),
               ]),
               SettingsSection(

--- a/lib/views/settings.dart
+++ b/lib/views/settings.dart
@@ -196,10 +196,16 @@ class Settings extends StatelessWidget {
                   ),
                 ),
                 SettingsTile.navigation(
-                  title: Text('SponsorBlock'),
+                  title: const Text('SponsorBlock'),
                   description: Text(locals.sponsorBlockDescription),
                   onPressed: openSponsorBlockSettings,
-                )
+                ),
+                SettingsTile.switchTile(
+                  title: const Text('Return YouTube Dislike'),
+                  description: Text(locals.returnYoutubeDislikeDescription),
+                  initialValue: _.useReturnYoutubeDislike,
+                  onToggle: _.toggleReturnYoutubeDislike,
+                ),
               ]),
               SettingsSection(
                 title: Text(locals.appearance),

--- a/lib/views/tv/tvSettings.dart
+++ b/lib/views/tv/tvSettings.dart
@@ -195,6 +195,12 @@ class TVSettings extends StatelessWidget {
                       description: locals.sponsorBlockDescription,
                       onSelected: openSponsorBlockSettings,
                     ),
+                    SettingsTile(
+                      title: 'Return YouTube Dislike',
+                      description: locals.returnYoutubeDislikeDescription,
+                      onSelected: (context) => _.toggleReturnYoutubeDislike(!_.useReturnYoutubeDislike),
+                      trailing: Switch(onChanged: (value) {}, value: _.useReturnYoutubeDislike),
+                    ),
                     SettingsTitle(title: locals.appearance),
                     SettingsTile(
                       title: locals.themeBrightness,

--- a/lib/views/tv/tvSettings.dart
+++ b/lib/views/tv/tvSettings.dart
@@ -131,6 +131,12 @@ class TVSettings extends StatelessWidget {
                       description: '${_.getLocaleDisplayName() ?? locals.followSystem}. ${locals.requiresRestart}',
                       onSelected: (context) => showSelectLanguage(context, _),
                     ),
+                    SettingsTile(
+                      title: 'Return YouTube Dislike',
+                      description: locals.returnYoutubeDislikeDescription,
+                      onSelected: (context) => _.toggleReturnYoutubeDislike(!_.useReturnYoutubeDislike),
+                      trailing: Switch(onChanged: (value) {}, value: _.useReturnYoutubeDislike),
+                    ),
 /*
                     SettingsTile(
                       title: locals.whenAppStartsShow,
@@ -194,12 +200,6 @@ class TVSettings extends StatelessWidget {
                       title: 'SponsorBlock',
                       description: locals.sponsorBlockDescription,
                       onSelected: openSponsorBlockSettings,
-                    ),
-                    SettingsTile(
-                      title: 'Return YouTube Dislike',
-                      description: locals.returnYoutubeDislikeDescription,
-                      onSelected: (context) => _.toggleReturnYoutubeDislike(!_.useReturnYoutubeDislike),
-                      trailing: Switch(onChanged: (value) {}, value: _.useReturnYoutubeDislike),
                     ),
                     SettingsTitle(title: locals.appearance),
                     SettingsTile(

--- a/lib/views/tv/tvVideoView.dart
+++ b/lib/views/tv/tvVideoView.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:get/get.dart';
+import 'package:intl/intl.dart';
+import 'package:invidious/controllers/settingsController.dart';
 import 'package:invidious/models/paginatedList.dart';
 import 'package:invidious/models/videoInList.dart';
+import 'package:invidious/utils.dart';
 import 'package:invidious/views/tv/tvButton.dart';
 import 'package:invidious/views/tv/tvChannelView.dart';
 import 'package:invidious/views/tv/tvExpandableText.dart';
@@ -85,7 +88,7 @@ class TvVideoView extends StatelessWidget {
                           ),
                         ),
                         Padding(
-                          padding: const EdgeInsets.only(top: 8),
+                          padding: const EdgeInsets.symmetric(vertical: 4),
                           child: Text(
                             _.video!.title,
                             maxLines: 2,
@@ -93,6 +96,39 @@ class TvVideoView extends StatelessWidget {
                             overflow: TextOverflow.ellipsis,
                           ),
                         ),
+                        Row(
+                          children: [
+                            const Icon(Icons.visibility, size: 20),
+                            Padding(
+                              padding: const EdgeInsets.only(left: 4),
+                              child: Text(compactCurrency.format(_.video?.viewCount)),
+                            ),
+                            const Padding(
+                                padding: EdgeInsets.symmetric(horizontal: 8.0),
+                                child: Text('•')
+                            ),
+                            const Icon(Icons.thumb_up, size: 20),
+                            Padding(
+                              padding: const EdgeInsets.only(left: 4),
+                              child: Text(compactCurrency.format(_.video?.likeCount)),
+                            ),
+                            if (_.getDislikes) ...[
+                              const Padding(
+                                  padding: EdgeInsets.symmetric(horizontal: 8.0),
+                                  child: Text('•')
+                              ),
+                              const Icon(Icons.thumb_down, size: 20),
+                              Padding(
+                                padding: const EdgeInsets.only(left: 4),
+                                child: Text(compactCurrency.format(_.dislikes)),
+                              ),
+                            ],
+                            const Padding(
+                                padding: EdgeInsets.symmetric(horizontal: 8.0),
+                                child: Text('•')
+                            ),
+                            Text(_.video?.publishedText ?? ''),
+                        ]),
                         Expanded(
                           child: Padding(
                             padding: const EdgeInsets.only(bottom: 10.0),

--- a/lib/views/video/info.dart
+++ b/lib/views/video/info.dart
@@ -15,8 +15,9 @@ import '../searchDelegate.dart';
 
 class VideoInfo extends StatelessWidget {
   Video video;
+  int? dislikes;
 
-  VideoInfo({super.key, required this.video});
+  VideoInfo({super.key, required this.video, this.dislikes});
 
   openChannel(BuildContext context) {
     navigatorKey.currentState?.push(MaterialPageRoute(settings: ROUTE_CHANNEL, builder: (context) => ChannelView(channelId: video.authorId ?? '')));
@@ -45,18 +46,6 @@ class VideoInfo extends StatelessWidget {
             child: Row(
               children: [
                 Visibility(
-                    visible: video.likeCount > 0,
-                    child: const Icon(
-                      Icons.thumb_up,
-                      size: 15,
-                    )),
-                Visibility(
-                    visible: video.likeCount > 0,
-                    child: Padding(
-                      padding: const EdgeInsets.only(left: 5.0),
-                      child: Text(compactCurrency.format(video.likeCount)),
-                    )),
-                Visibility(
                     visible: video.viewCount > 0,
                     child: const Icon(
                       Icons.visibility,
@@ -65,8 +54,38 @@ class VideoInfo extends StatelessWidget {
                 Visibility(
                     visible: video.viewCount > 0,
                     child: Padding(
-                      padding: const EdgeInsets.only(left: 5.0),
+                      padding: const EdgeInsets.only(left: 3.0),
                       child: Text(compactCurrency.format(video.viewCount)),
+                    )),
+                Visibility(
+                    visible: video.likeCount > 0,
+                    child: const Padding(
+                      padding: EdgeInsets.only(left: 5.0),
+                      child: Icon(
+                          Icons.thumb_up,
+                          size: 15,
+                        ),
+                    )),
+                Visibility(
+                    visible: video.likeCount > 0,
+                    child: Padding(
+                      padding: const EdgeInsets.only(left: 3.0),
+                      child: Text(compactCurrency.format(video.likeCount)),
+                    )),
+                Visibility(
+                    visible: (dislikes ?? 0) > 0,
+                    child: const Padding(
+                      padding: EdgeInsets.only(left: 5.0),
+                      child: Icon(
+                        Icons.thumb_down,
+                        size: 15,
+                      ),
+                    )),
+                Visibility(
+                    visible: (dislikes ?? 0) > 0,
+                    child: Padding(
+                      padding: const EdgeInsets.only(left: 3.0),
+                      child: Text(compactCurrency.format(dislikes)),
                     )),
                 Expanded(child: Container()),
                 Visibility(

--- a/lib/views/video/innverView.dart
+++ b/lib/views/video/innverView.dart
@@ -73,6 +73,7 @@ class VideoInnerView extends StatelessWidget {
                     child: <Widget>[
                       VideoInfo(
                         video: video,
+                        dislikes: videoController.dislikes,
                       ),
                       CommentsContainer(
                         video: video,

--- a/lib/views/video/innverViewTablet.dart
+++ b/lib/views/video/innverViewTablet.dart
@@ -88,6 +88,7 @@ class VideoTabletInnerView extends StatelessWidget {
                               child: <Widget>[
                                 VideoInfo(
                                   video: video,
+                                  dislikes: videoController.dislikes,
                                 ),
                                 CommentsContainer(video: video),
                                 RecommendedVideos(video: video)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.7.16+263
+version: 1.7.17+264
 
 environment:
   sdk: '>=2.19.1 <3.0.0'


### PR DESCRIPTION
* Add integration for https://returnyoutubedislike.com/ to all clients - this is off by default and can be enabled in settings - addresses https://github.com/lamarios/clipious/issues/17 if desired
* Add video info (views, likes, and publish text) to TV UI
- [x] I have updated the version and build number accordingly