### PR TITLE
Unicode search suggestions support and fixed search suggestions whilst not authed

### DIFF
--- a/lib/service.dart
+++ b/lib/service.dart
@@ -266,8 +266,19 @@ class Service {
 
     var headers = getAuthenticationHeaders(currentlySelectedServer);
 
-    final response = await http.get(buildUrl(SEARCH_SUGGESTIONS, pathParams: {":query": query}), headers: headers);
-    return SearchSuggestion.fromJson(handleResponse(response));
+    final response = await http.get(buildUrl(SEARCH_SUGGESTIONS, pathParams: {":query": Uri.encodeQueryComponent(query)}), headers: headers);
+    SearchSuggestion search = SearchSuggestion.fromJson(handleResponse(response));
+    if (search.suggestions.any((element) => element.contains(";"))) {
+      search.suggestions = search
+          .suggestions
+          .map((s) =>
+            s.split(";")
+              .where((e) => e.isNotEmpty && e.startsWith("&#"))
+              .map((e) => String.fromCharCode(int.parse(e.replaceAll("&#", "")))).toList().join("")
+          ).toList();
+    }
+
+    return search;
   }
 
   Future<bool> isValidServer(String serverUrl) async {

--- a/lib/service.dart
+++ b/lib/service.dart
@@ -206,7 +206,7 @@ class Service {
   }
 
   Future<SearchResults> search(String query) async {
-    Uri uri = buildUrl(SEARCH, pathParams: {':q': query});
+    Uri uri = buildUrl(SEARCH, pathParams: {':q': Uri.encodeQueryComponent(query)});
     final response = await http.get(uri);
     Iterable i = handleResponse(response);
     // only getting videos for now
@@ -262,11 +262,7 @@ class Service {
   }
 
   Future<SearchSuggestion> getSearchSuggestion(String query) async {
-    var currentlySelectedServer = db.getCurrentlySelectedServer();
-
-    var headers = getAuthenticationHeaders(currentlySelectedServer);
-
-    final response = await http.get(buildUrl(SEARCH_SUGGESTIONS, pathParams: {":query": Uri.encodeQueryComponent(query)}), headers: headers);
+    final response = await http.get(buildUrl(SEARCH_SUGGESTIONS, pathParams: {":query": Uri.encodeQueryComponent(query)}));
     SearchSuggestion search = SearchSuggestion.fromJson(handleResponse(response));
     if (search.suggestions.any((element) => element.contains(";"))) {
       search.suggestions = search

--- a/lib/views/tv/tvVideoView.dart
+++ b/lib/views/tv/tvVideoView.dart
@@ -120,7 +120,7 @@ class TvVideoView extends StatelessWidget {
                               const Icon(Icons.thumb_down, size: 20),
                               Padding(
                                 padding: const EdgeInsets.only(left: 4),
-                                child: Text(compactCurrency.format(_.dislikes)),
+                                child: Text(compactCurrency.format(_.dislikes).replaceAll(".00", "")),
                               ),
                             ],
                             const Padding(

--- a/lib/views/video/info.dart
+++ b/lib/views/video/info.dart
@@ -85,7 +85,7 @@ class VideoInfo extends StatelessWidget {
                     visible: (dislikes ?? 0) > 0,
                     child: Padding(
                       padding: const EdgeInsets.only(left: 3.0),
-                      child: Text(compactCurrency.format(dislikes)),
+                      child: Text(compactCurrency.format(dislikes ?? 0).replaceAll(".00", "")),
                     )),
                 Expanded(child: Container()),
                 Visibility(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.7.16+263
+version: 1.7.17+264
 
 environment:
   sdk: '>=2.19.1 <3.0.0'


### PR DESCRIPTION
Bug fixes:
* Fix https://github.com/lamarios/clipious/issues/13 - unicode characters inside the search suggestions are parsed
* Fix bug where search suggestions would not work if you were not logged into an instance (due to unnecessary auth throwing an error)
* Fix bug caused by `dislikes` being null and `Visibility` trying to render/compute the text for the dislike button

Enhancements:
* Ensure search queries (search & search suggestions) use URL-safe encoded characters