### PR TITLE
Add Accrescent Badge to README, Badges Overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,17 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 ## Installation
 The best way to install is to get it directly from the release page. Using [Obtainium](https://github.com/ImranR98/Obtainium) can help keeping the app up to date.
 
-It is also available on the Google Play Store and IzzyOnDroid:
+It is also available on the Google Play Store IzzyOnDroid, Accrescent:
 
-[![Clipious on the Google Play Store](./assets/google_play_small.png)](https://play.google.com/store/apps/details?id=com.github.lamarios.clipious)
-[![Clipious on IzzyOnDroid](./assets/IzzyOnDroid_small.png)](https://apt.izzysoft.de/fdroid/index/apk/com.github.lamarios.clipious/)
+[<img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png"
+      alt='Get it on Google Play'
+      height="80">](https://play.google.com/store/apps/details?id=com.github.lamarios.clipious)
+[<img src="https://gitlab.com/IzzyOnDroid/repo/-/raw/master/assets/IzzyOnDroid.png"
+      alt='Get it on IzzyOnDroid'
+      height="80">](https://apt.izzysoft.de/fdroid/index/apk/com.github.lamarios.clipious/)
+[<img src="https://accrescent.app/badges/get-it-on.png"
+      alt='Get it on Accrescent'
+      height="80">](https://accrescent.app/app/com.github.lamarios.clipious)
 
 ## Screenshots
 ### Phone

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 ## Installation
 The best way to install is to get it directly from the release page. Using [Obtainium](https://github.com/ImranR98/Obtainium) can help keeping the app up to date.
 
-It is also available on the Google Play Store IzzyOnDroid, Accrescent:
+It is also available on the Google Play Store, IzzyOnDroid, and Accrescent:
 
 [<img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png"
       alt='Get it on Google Play'


### PR DESCRIPTION
This PR does a few things:

- It adds the Accrescent badge to the README.
- It changes the Play Store and IzzyOnDroid badges to also use links instead of static assets in your repo.

The latter was done for 2 reasons:

1. The ones you were using had a border around them which made it very hard to keep all 3 at the same size without one being too large or too small in comparison.
2. Using the upstream links means that if Play Store, IzzyOnDroid or Accrescent ever changes or updates its badge, you automatically get the up-to-date version without having to do anything on your end.

I added Accrescent last and left the recommendation of Obtainium as the optimal choice, as I didn't know if you were planning to change that, so everything else has been left as is.

Thanks!