### PR TITLE
TV UI improvements

### DIFF
--- a/lib/controllers/playlistController.dart
+++ b/lib/controllers/playlistController.dart
@@ -40,6 +40,10 @@ class PlaylistController extends GetxController {
     MiniPlayerController.to()?.playVideo(playlist.videos, goBack: false);
   }
 
+  scrollToTop() {
+    scrollController.animateTo(0, duration: animationDuration ~/ 2, curve: Curves.easeInOutQuad);
+  }
+
   getAllVideos() async {
     if (playlist.videoCount > 0 && playlist.videos.length < playlist.videoCount) {
       loading = true;

--- a/lib/controllers/settingsController.dart
+++ b/lib/controllers/settingsController.dart
@@ -157,6 +157,17 @@ class SettingsController extends GetxController {
     db.saveSetting(SettingsValue(SUBTITLE_SIZE, subtitleSize.toString()));
   }
 
+  setSubtitleSize(int value) {
+    if (value < 1) {
+      subtitleSize = 1;
+    } else {
+      subtitleSize = value.toDouble();
+    }
+
+    update();
+    db.saveSetting(SettingsValue(SUBTITLE_SIZE, subtitleSize.toString()));
+  }
+
   toggleRememberSubtitles(bool value) {
     db.saveSetting(SettingsValue(REMEMBER_LAST_SUBTITLE, value.toString()));
     rememberSubtitles = value;
@@ -176,6 +187,20 @@ class SettingsController extends GetxController {
     update();
     db.saveSetting(SettingsValue(SEARCH_HISTORY_LIMIT, searchHistoryLimit.toString()));
     if (!increase) {
+      db.clearExcessSearchHistory();
+    }
+  }
+
+  setHistoryLimit(int value) {
+    if (value < 1) {
+      searchHistoryLimit = 1;
+    } else if (value <= 30) {
+      searchHistoryLimit = value;
+    }
+
+    update();
+    db.saveSetting(SettingsValue(SEARCH_HISTORY_LIMIT, searchHistoryLimit.toString()));
+    if (value < searchHistoryLimit) {
       db.clearExcessSearchHistory();
     }
   }

--- a/lib/controllers/tvChannelController.dart
+++ b/lib/controllers/tvChannelController.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'package:invidious/controllers/channelController.dart';
+import 'package:invidious/globals.dart';
+
+class TvChannelController extends ChannelController{
+  final ScrollController scrollController = ScrollController();
+  TvChannelController(super.channelId);
+
+  @override
+  void onClose() {
+    scrollController.dispose();
+    super.onClose();
+  }
+
+  scrollToTop(bool scroll){
+    if(scroll) {
+      scrollController.animateTo(0, duration: animationDuration ~/ 2, curve: Curves.easeInOutQuad);
+    }
+  }
+
+}

--- a/lib/controllers/tvPlayerController.dart
+++ b/lib/controllers/tvPlayerController.dart
@@ -5,6 +5,7 @@ import 'package:flutter/src/services/hardware_keyboard.dart';
 import 'package:flutter/src/widgets/focus_manager.dart';
 import 'package:get/get.dart';
 import 'package:invidious/controllers/playerController.dart';
+import 'package:invidious/main.dart';
 import 'package:logging/logging.dart';
 
 import '../utils.dart';
@@ -37,7 +38,13 @@ class TvPlayerController extends GetxController {
   }
 
   @override
-  void onReady() {}
+  void onReady() {
+  }
+
+  @override
+  void onClose() {
+    super.onClose();
+  }
 
   bool get isPlaying => PlayerController.to()?.videoController?.isPlaying() ?? false;
 
@@ -84,9 +91,10 @@ class TvPlayerController extends GetxController {
   }
 
   KeyEventResult handleRemoteEvents(FocusNode node, KeyEvent event) {
-    log.fine('Other key event: ${event.logicalKey}');
+    // log.fine('Other key event: ${event.logicalKey}, control focused: ${controlFocusNode.hasFocus}, settings focused: ${settingsFocusNode.hasFocus}, queue focused: ${queueFocusNode.hasFocus}');
     showControls();
     if (event is KeyUpEvent) {
+
       if (!showSettings) {
         if (event.logicalKey == LogicalKeyboardKey.arrowRight) {
           PlayerController.to()?.videoController?.seekTo(currentPosition + const Duration(seconds: 10));

--- a/lib/controllers/tvPlayerController.dart
+++ b/lib/controllers/tvPlayerController.dart
@@ -5,11 +5,13 @@ import 'package:flutter/src/services/hardware_keyboard.dart';
 import 'package:flutter/src/widgets/focus_manager.dart';
 import 'package:get/get.dart';
 import 'package:invidious/controllers/playerController.dart';
+import 'package:invidious/globals.dart';
 import 'package:invidious/main.dart';
 import 'package:invidious/models/baseVideo.dart';
 import 'package:invidious/models/videoInList.dart';
 import 'package:logging/logging.dart';
 
+import '../models/video.dart';
 import '../utils.dart';
 
 const Duration controlFadeOut = Duration(seconds: 4);
@@ -17,22 +19,26 @@ const Duration throttleDuration = Duration(milliseconds: 250);
 
 class TvPlayerController extends GetxController {
   Logger log = Logger('TvPlayerController');
-  final List<BaseVideo> videos;
 
-  TvPlayerController({required this.videos});
+  late List<BaseVideo> videos;
 
   static TvPlayerController? to() => safeGet();
   double progress = 0;
   double controlsOpacity = 0;
   Duration currentPosition = Duration.zero;
   bool buffering = true;
+  bool loading = true;
   bool showSettings = false;
   bool showQueue = false;
+  bool showControls = false;
+  late Video currentlyPlaying;
 
   Duration get videoLength => Duration(seconds: PlayerController.to()?.video.lengthSeconds ?? 0);
 
+  TvPlayerController({required this.videos});
+
   togglePlayPause() {
-    showControls();
+    showUi();
     if (isPlaying) {
       log.info('Pausing video');
       PlayerController.to()?.videoController?.pause();
@@ -44,7 +50,13 @@ class TvPlayerController extends GetxController {
   }
 
   @override
-  void onReady() {}
+  void onReady() async {
+    currentlyPlaying = await service.getVideo(videos[0].videoId);
+    loading = false;
+    update();
+  }
+
+  bool get isShowUi => controlsOpacity == 1;
 
   @override
   void onClose() {
@@ -52,6 +64,8 @@ class TvPlayerController extends GetxController {
   }
 
   bool get isPlaying => PlayerController.to()?.videoController?.isPlaying() ?? false;
+
+  int get currentlyPlayingIndex => videos.indexWhere((element) => element.videoId == currentlyPlaying.videoId);
 
   handleVideoEvent(BetterPlayerEvent event) {
     switch (event.betterPlayerEventType) {
@@ -62,6 +76,9 @@ class TvPlayerController extends GetxController {
       case BetterPlayerEventType.seekTo:
         Duration currentPosition = (event.parameters?['duration'] as Duration);
         setProgress(currentPosition);
+        break;
+      case BetterPlayerEventType.finished:
+        playNext();
         break;
       case BetterPlayerEventType.bufferingStart:
         buffering = true;
@@ -81,7 +98,7 @@ class TvPlayerController extends GetxController {
     update();
   }
 
-  showControls() {
+  showUi() {
     controlsOpacity = 1;
     update();
     hideControls();
@@ -92,44 +109,116 @@ class TvPlayerController extends GetxController {
       controlsOpacity = 0;
       showSettings = false;
       showQueue = false;
+      showControls = false;
       update();
     });
   }
 
+  fastForward() {
+    PlayerController.to()?.videoController?.seekTo(currentPosition + const Duration(seconds: 10));
+  }
+
+  fastRewind() {
+    PlayerController.to()?.videoController?.seekTo(currentPosition - const Duration(seconds: 10));
+  }
+
+  playNext() async {
+    int current = currentlyPlayingIndex;
+    int newIndex = 0;
+    if (current == videos.length - 1) {
+      newIndex = 0;
+    } else {
+      newIndex = current + 1;
+    }
+
+    loading = true;
+    update();
+    currentlyPlaying = await service.getVideo(videos[newIndex].videoId);
+    PlayerController.to()?.switchVideo(currentlyPlaying);
+    loading = false;
+    update();
+  }
+
+  playPrevious() async {
+    int current = currentlyPlayingIndex;
+    int newIndex = 0;
+    if (current == 0) {
+      newIndex = videos.length - 1;
+    } else {
+      newIndex = current - 1;
+    }
+    loading = true;
+    update();
+    currentlyPlaying = await service.getVideo(videos[newIndex].videoId);
+    PlayerController.to()?.switchVideo(currentlyPlaying);
+    loading = false;
+    update();
+  }
+
+
+  displaySettings() {
+    showSettings = true;
+    showControls = false;
+    update();
+  }
+
+  displayQueue() {
+    showQueue = true;
+    showControls = false;
+    update();
+  }
+
   KeyEventResult handleRemoteEvents(FocusNode node, KeyEvent event) {
-    // log.fine('Other key event: ${event.logicalKey}, control focused: ${controlFocusNode.hasFocus}, settings focused: ${settingsFocusNode.hasFocus}, queue focused: ${queueFocusNode.hasFocus}');
-    showControls();
-    if (event is KeyUpEvent) {
-      if (!showSettings && !showQueue) {
+    bool timeLineControl = !showQueue && !showSettings && !showControls;
+    log.fine('Key: ${event.logicalKey}, Timeline control: $timeLineControl, showQueue: $showQueue, showSettings: $showSettings, showControls: $showControls}');
+    showUi();
+
+    // looks like back is activate on pressdown and not press up
+    if (event is KeyUpEvent && !timeLineControl && event.logicalKey == LogicalKeyboardKey.goBack) {
+      if (showQueue || showSettings) {
+        showQueue = false;
+        showSettings = false;
+        showControls = true;
+      } else {
+        showQueue = false;
+        showSettings = false;
+        showControls = false;
+      }
+      update();
+      return KeyEventResult.handled;
+    } else if (event is KeyUpEvent) {
+      if (timeLineControl) {
         if (event.logicalKey == LogicalKeyboardKey.arrowRight) {
-          PlayerController.to()?.videoController?.seekTo(currentPosition + const Duration(seconds: 10));
+          fastForward();
         } else if (event.logicalKey == LogicalKeyboardKey.arrowLeft) {
-          PlayerController.to()?.videoController?.seekTo(currentPosition - const Duration(seconds: 10));
+          fastRewind();
         } else if (event.logicalKey == LogicalKeyboardKey.select) {
-          togglePlayPause();
-        } else if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
-          log.fine('showing video settings');
-          showSettings = true;
-          update();
-        } else if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
-          log.fine('showing video queue');
-          showQueue = true;
+          showControls = true;
           update();
         }
-      }
+      } else {}
     }
     if (event is KeyRepeatEvent) {
-      if (!showSettings && !showQueue) {
+      if (timeLineControl) {
         if (event.logicalKey == LogicalKeyboardKey.arrowRight) {
-          EasyThrottle.throttle('hold-seek-forward', throttleDuration, () => PlayerController.to()?.videoController?.seekTo(currentPosition + const Duration(seconds: 10)));
+          EasyThrottle.throttle('hold-seek-forward', throttleDuration, fastForward);
         }
         if (event.logicalKey == LogicalKeyboardKey.arrowLeft) {
-          EasyThrottle.throttle('hold-seek-backward', throttleDuration, () => PlayerController.to()?.videoController?.seekTo(currentPosition - const Duration(seconds: 10)));
+          EasyThrottle.throttle('hold-seek-backward', throttleDuration, fastRewind);
         }
       }
     }
     return KeyEventResult.ignored;
   }
 
-  void playFromQueue(VideoInList video) {}
+  Future<void> playFromQueue(VideoInList video) async {
+    print('hello');
+    showQueue = false;
+    loading = true;
+    update();
+    currentlyPlaying = await service.getVideo(video.videoId);
+    PlayerController.to()?.switchVideo(currentlyPlaying);
+    loading = false;
+    update();
+  }
 }

--- a/lib/controllers/tvVideoController.dart
+++ b/lib/controllers/tvVideoController.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:invidious/controllers/videoController.dart';
+import 'package:invidious/globals.dart';
+
+class TvVideoController extends VideoController {
+  final ScrollController scrollController = ScrollController();
+
+  TvVideoController({required super.videoId});
+
+  @override
+  void onClose() {
+    scrollController.dispose();
+    super.onClose();
+  }
+
+  scrollUp() {
+    scrollController.animateTo(0, duration: animationDuration ~/ 2, curve: Curves.easeInOutQuad);
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -57,6 +57,8 @@ Future<void> main() async {
   runApp(const MyApp());
 }
 
+late ColorScheme darkColorScheme;
+
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
@@ -77,7 +79,6 @@ class MyApp extends StatelessWidget {
 
           return DynamicColorBuilder(builder: (ColorScheme? lightDynamic, ColorScheme? darkDynamic) {
             ColorScheme lightColorScheme;
-            ColorScheme darkColorScheme;
 
             if (useDynamicTheme && lightDynamic != null && darkDynamic != null) {
               // On Android S+ devices, use the provided dynamic color scheme.

--- a/lib/models/recommendedVideo.dart
+++ b/lib/models/recommendedVideo.dart
@@ -1,4 +1,5 @@
 import 'package:invidious/models/baseVideo.dart';
+import 'package:invidious/models/videoInList.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 import 'imageObject.dart';
@@ -15,4 +16,8 @@ class RecommendedVideo extends BaseVideo {
   factory RecommendedVideo.fromJson(Map<String, dynamic> json) => _$RecommendedVideoFromJson(json);
 
   Map<String, dynamic> toJson() => _$RecommendedVideoToJson(this);
+
+  static VideoInList toVideoInList(RecommendedVideo e) {
+    return VideoInList(e.title, e.videoId, e.lengthSeconds, 0, e.author, '', 'authorUrl', 0, '', e.videoThumbnails);
+  }
 }

--- a/lib/views/playlistView.dart
+++ b/lib/views/playlistView.dart
@@ -1,4 +1,3 @@
-import 'package:fbroadcast/fbroadcast.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_swipe_action_cell/core/cell.dart';
@@ -6,15 +5,12 @@ import 'package:get/get.dart';
 import 'package:invidious/main.dart';
 import 'package:invidious/models/errors/invidiousServiceError.dart';
 import 'package:invidious/models/imageObject.dart';
-import 'package:invidious/models/video.dart';
 import 'package:invidious/models/videoInList.dart';
 import 'package:invidious/myRouteObserver.dart';
 import 'package:invidious/utils.dart';
 import 'package:invidious/views/components/compactVideo.dart';
-import 'package:invidious/views/components/miniPlayerAware.dart';
 import 'package:invidious/views/components/videoThumbnail.dart';
 import 'package:invidious/views/video.dart';
-import 'package:invidious/views/video/player.dart';
 
 import '../controllers/playlistController.dart';
 import '../globals.dart';

--- a/lib/views/playlists/playlist.dart
+++ b/lib/views/playlists/playlist.dart
@@ -12,6 +12,7 @@ import 'package:invidious/myRouteObserver.dart';
 import 'package:invidious/utils.dart';
 import 'package:invidious/views/components/videoThumbnail.dart';
 import 'package:invidious/views/playlistView.dart';
+import 'package:invidious/views/tv/tvPlaylistView.dart';
 import 'package:invidious/views/tv/tvVideoGridView.dart';
 
 import '../../models/searchSortBy.dart';
@@ -21,9 +22,8 @@ class PlaylistItem extends StatelessWidget {
   final Playlist playlist;
   final bool canDeleteVideos;
   final bool isTv;
-  final bool cameFromSearch;
 
-  const PlaylistItem({super.key, required this.playlist, required this.canDeleteVideos, this.isTv = false, this.cameFromSearch = false});
+  const PlaylistItem({super.key, required this.playlist, required this.canDeleteVideos, this.isTv = false});
 
   openPlayList(BuildContext context) {
     navigatorKey.currentState?.push(MaterialPageRoute(
@@ -35,28 +35,9 @@ class PlaylistItem extends StatelessWidget {
   }
 
   openTvPlaylist(BuildContext context) {
-    if (cameFromSearch) {
-      Navigator.of(context).push(MaterialPageRoute(
-        builder: (builder) => TvGridView(
-          paginatedVideoList: PlaylistSearchPaginatedList<VideoInList>(
-              query: playlist.playlistId,
-              items: [],
-              type: SearchType.playlist,
-              getFromResults: (_) => [],
-              sortBy: SearchSortBy.relevance
-          ),
-          title: playlist.title,
-          shouldRefetch: true,
-        ),
-      ));
-    } else {
-      Navigator.of(context).push(MaterialPageRoute(
-        builder: (builder) => TvGridView(
-          paginatedVideoList: FixedItemList<VideoInList>(playlist.videos),
-          title: playlist.title,
-        ),
-      ));
-    }
+    Navigator.of(context).push(MaterialPageRoute(
+      builder: (context) => TvPlaylistView(playlist: playlist, canDeleteVideos: false),
+    ));
   }
 
   @override
@@ -78,7 +59,7 @@ class PlaylistItem extends StatelessWidget {
             top: (10 * i).toDouble(),
             left: (15 * i).toDouble(),
             child: SizedBox(
-              width: isTv ? (cameFromSearch ? 120 : 200) : 100,
+              width: isTv ? 210 : 100,
               child: AspectRatio(
                 aspectRatio: 16 / 9,
                 child: Opacity(
@@ -104,53 +85,50 @@ class PlaylistItem extends StatelessWidget {
           return Focus(
             onKeyEvent: (node, event) => onTvSelect(event, context, (_) => openTvPlaylist(context)),
             autofocus: false,
-            child: Padding(
-              padding: const EdgeInsets.all(8.0),
-              child: Builder(
-                builder: (ctx) {
-                  final bool hasFocus = Focus.of(ctx).hasFocus;
+            child: AspectRatio(
+              aspectRatio: 16/13,
+              child: Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Builder(builder: (ctx) {
+                    final bool hasFocus = Focus.of(ctx).hasFocus;
 
-                  return GestureDetector(
-                    child: AnimatedScale(
-                      curve: Curves.easeInOutQuad,
-                      duration: animationDuration ~/2,
-                      scale: hasFocus ? 1 : 0.9,
-                      child: AnimatedContainer(
-                          decoration: BoxDecoration(
-                            borderRadius: BorderRadius.circular(15),
-                            color: hasFocus ? colors.primaryContainer : colors.background,
-                          ),
-                          duration: animationDuration,
-                          child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.center,
-                              children: [
-                                SizedBox(
-                                    width: cameFromSearch ? 200 : 400,
-                                    height: cameFromSearch ? 120 : 160,
-                                    child: Padding(
-                                      padding: const EdgeInsets.only(left: 20.0, right: 8.0, top: 8.0, bottom: 8.0),
-                                      child: Stack(
-                                        children: thumbs,
-                                      ),
-                                    )),
-                                Expanded(
-                                    child: Text(
-                                      playlist.title,
-                                      style: TextStyle(
-                                          color: colors.primary,
-                                          fontSize: 20.0
-                                      ),
-                                    )),
-                                Padding(
-                                    padding: cameFromSearch ? EdgeInsets.zero : const EdgeInsets.only(bottom: 8.0),
-                                    child: Text(locals.nVideos(playlist.videoCount))
-                                ),
-                              ],
+                    return GestureDetector(
+                      child: AnimatedScale(
+                          curve: Curves.easeInOutQuad,
+                          duration: animationDuration ~/ 2,
+                          scale: hasFocus ? 1 : 0.9,
+                          child: AnimatedContainer(
+                            decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(15),
+                              color: hasFocus ? colors.primaryContainer : colors.background,
+                            ),
+                            duration: animationDuration,
+                            child: Padding(
+                              padding: const EdgeInsets.all(8.0),
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.center,
+                                children: [
+                                  SizedBox(
+                                      height: 140,
+                                      child: AspectRatio(
+                                        aspectRatio: 16 / 9,
+                                        child: Stack(
+                                          children: thumbs,
+                                        ),
+                                      )),
+                                  Expanded(
+                                      child: Text(
+                                    playlist.title,
+                                    overflow: TextOverflow.ellipsis,
+                                    style: TextStyle(color: colors.primary, fontSize: 20.0),
+                                  )),
+                                  Padding(padding: const EdgeInsets.only(bottom: 8.0), child: Text(locals.nVideos(playlist.videoCount))),
+                                ],
+                              ),
                             ),
                           )),
-                  );
-                }
-              )
+                    );
+                  })),
             ),
           );
         } else {
@@ -174,9 +152,9 @@ class PlaylistItem extends StatelessWidget {
                           )),
                       Expanded(
                           child: Text(
-                            playlist.title,
-                            style: TextStyle(color: colors.primary),
-                          )),
+                        playlist.title,
+                        style: TextStyle(color: colors.primary),
+                      )),
                       Text(locals.nVideos(playlist.videoCount)),
                     ],
                   ),

--- a/lib/views/tv/settings/tvManageSingleServer.dart
+++ b/lib/views/tv/settings/tvManageSingleServer.dart
@@ -8,6 +8,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import '../../../controllers/serverSettingsController.dart';
 import '../../../models/db/server.dart';
 import '../../../utils.dart';
+import '../tvTextField.dart';
 
 class TvManageSingleServer extends StatelessWidget {
   final Server server;
@@ -19,6 +20,7 @@ class TvManageSingleServer extends StatelessWidget {
     TextEditingController userController = TextEditingController();
     TextEditingController passwordController = TextEditingController();
     FocusNode focusNode = FocusNode();
+    ColorScheme colors = Theme.of(context).colorScheme;
 
     showTvDialog(
         context: context,
@@ -26,21 +28,29 @@ class TvManageSingleServer extends StatelessWidget {
               Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  TextField(
-                      autofocus: true,
-                      focusNode: focusNode,
+                  Padding(
+                    padding: const EdgeInsets.all(8.0),
+                    child: TvTextField(
+                        leading: Icon(Icons.person, color: colors.secondary,),
+                        autofocus: true,
+                        focusNode: focusNode,
+                        textInputAction: TextInputAction.next,
+                        controller: userController,
+                        autocorrect: false,
+                        autofillHints: const [AutofillHints.username, AutofillHints.email],
+                        decoration: InputDecoration(label: Text(locals.username, style: TextStyle(color: colors.secondary),))),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.all(8.0),
+                    child: TvTextField(
+                      leading: Icon(Icons.password, color: colors.secondary,),
+                      obscureText: true,
                       textInputAction: TextInputAction.next,
-                      controller: userController,
                       autocorrect: false,
-                      autofillHints: const [AutofillHints.username, AutofillHints.email],
-                      decoration: InputDecoration(label: Text(locals.username))),
-                  TextField(
-                    obscureText: true,
-                    textInputAction: TextInputAction.next,
-                    autocorrect: false,
-                    controller: passwordController,
-                    autofillHints: const [AutofillHints.password],
-                    decoration: InputDecoration(label: Text(locals.password)),
+                      controller: passwordController,
+                      autofillHints: const [AutofillHints.password],
+                      decoration: InputDecoration(label: Text(locals.password, style: TextStyle(color: colors.secondary),)),
+                    ),
                   ),
                 ],
               )

--- a/lib/views/tv/settings/tvSearchHistorySettings.dart
+++ b/lib/views/tv/settings/tvSearchHistorySettings.dart
@@ -18,16 +18,16 @@ class TvSearchHistorySettings extends StatelessWidget {
     showTvDialog(
         context: context,
         builder: (BuildContext context) => [
-          Column(
-            children: [
-              Text(locals.clearSearchHistory, textScaleFactor: 3),
-              Padding(
-                padding: const EdgeInsets.only(top: 36),
-                child: Text(locals.irreversibleAction, textScaleFactor: 1.5),
-              )
+              Column(
+                children: [
+                  Text(locals.clearSearchHistory, textScaleFactor: 3),
+                  Padding(
+                    padding: const EdgeInsets.only(top: 36),
+                    child: Text(locals.irreversibleAction, textScaleFactor: 1.5),
+                  )
+                ],
+              ),
             ],
-          ),
-        ],
         actions: [
           TvButton(
             onPressed: (context) {
@@ -70,36 +70,10 @@ class TvSearchHistorySettings extends StatelessWidget {
                 trailing: Switch(onChanged: (value) {}, value: _.useSearchHistory),
                 onSelected: (ctx) => _.toggleSearchHistory(!_.useSearchHistory),
               ),
-              SettingsTile(
+              AdjustmentSettingTile(
                 title: locals.searchHistoryLimit,
                 description: locals.searchHistoryLimitDescription,
-                trailing: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Padding(
-                      padding: const EdgeInsets.only(right: 8.0),
-                      child: TvButton(
-                          onPressed: (ctx) => _.useSearchHistory ? _.changeSearchHistoryLimit(increase: false) : null,
-                          child: const Padding(
-                            padding: EdgeInsets.all(8.0),
-                            child: Icon(Icons.remove),
-                          )),
-                    ),
-                    Text(
-                      _.searchHistoryLimit.toString(),
-                      style: textTheme.bodyLarge,
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.only(left: 8.0),
-                      child: TvButton(
-                          onPressed: (ctx) => _.useSearchHistory ? _.changeSearchHistoryLimit(increase: true) : null,
-                          child: const Padding(
-                            padding: EdgeInsets.all(8.0),
-                            child: Icon(Icons.add),
-                          )),
-                    ),
-                  ],
-                ),
+                value: _.searchHistoryLimit, onNewValue: _.setHistoryLimit,
               ),
               SettingsTile(
                 title: locals.clearSearchHistory,

--- a/lib/views/tv/tvHorizontalVideoList.dart
+++ b/lib/views/tv/tvHorizontalVideoList.dart
@@ -6,20 +6,19 @@ import 'package:invidious/views/tv/tvVideoItem.dart';
 import '../../models/paginatedList.dart';
 import '../../models/videoInList.dart';
 
-class TvHorizontalVideoList extends StatelessWidget {
-  final PaginatedList<VideoInList> paginatedVideoList;
-  final Function(BuildContext context, VideoInList video)? onSelect;
+class TvHorizontalItemList<T> extends StatelessWidget {
+  final PaginatedList<T> paginatedList;
   final String? tags;
+  final Widget Function(BuildContext context, int index, T item) buildItem;
 
-  const TvHorizontalVideoList({Key? key, this.tags, required this.paginatedVideoList, this.onSelect}) : super(key: key);
+  const TvHorizontalItemList({Key? key, this.tags, required this.paginatedList, required this.buildItem}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-
-    return GetBuilder<VideoListController>(
+    return GetBuilder<ItemListController<T>>(
       global: tags != null,
       tag: tags,
-      init: VideoListController(videoList: paginatedVideoList),
+      init: ItemListController(itemList: paginatedList),
       builder: (_) => Stack(
         children: [
           _.loading
@@ -32,14 +31,36 @@ class TvHorizontalVideoList extends StatelessWidget {
             child: ListView.builder(
               scrollDirection: Axis.horizontal,
               controller: _.scrollController,
-              itemCount: _.videos.length,
+              itemCount: _.items.length,
               itemBuilder: (context, index) {
-                VideoInList e = _.videos[index];
-                return TvVideoItem(key: ValueKey('video-item-${e.videoId}'),video: e, autoFocus: index == 0, onSelect: onSelect,);
+                T e = _.items[index];
+                return buildItem(context, index, e);
               },
             ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+class TvHorizontalVideoList extends StatelessWidget {
+  final PaginatedList<VideoInList> paginatedVideoList;
+  final Function(BuildContext context, VideoInList video)? onSelect;
+  final String? tags;
+  final int autoFocusedIndex;
+
+  const TvHorizontalVideoList({Key? key, this.tags, required this.paginatedVideoList, this.onSelect, this.autoFocusedIndex = 0}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return TvHorizontalItemList<VideoInList>(
+      paginatedList: paginatedVideoList,
+      buildItem: (context, index, e) => TvVideoItem(
+        key: ValueKey('video-item-${e.videoId}'),
+        video: e,
+        autoFocus: index == autoFocusedIndex,
+        onSelect: onSelect,
       ),
     );
   }

--- a/lib/views/tv/tvHorizontalVideoList.dart
+++ b/lib/views/tv/tvHorizontalVideoList.dart
@@ -8,9 +8,10 @@ import '../../models/videoInList.dart';
 
 class TvHorizontalVideoList extends StatelessWidget {
   final PaginatedList<VideoInList> paginatedVideoList;
+  final Function(BuildContext context, VideoInList video)? onSelect;
   final String? tags;
 
-  const TvHorizontalVideoList({Key? key, this.tags, required this.paginatedVideoList}) : super(key: key);
+  const TvHorizontalVideoList({Key? key, this.tags, required this.paginatedVideoList, this.onSelect}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -34,7 +35,7 @@ class TvHorizontalVideoList extends StatelessWidget {
               itemCount: _.videos.length,
               itemBuilder: (context, index) {
                 VideoInList e = _.videos[index];
-                return TvVideoItem(key: ValueKey('video-item-${e.videoId}'),video: e, autoFocus: index == 0);
+                return TvVideoItem(key: ValueKey('video-item-${e.videoId}'),video: e, autoFocus: index == 0, onSelect: onSelect,);
               },
             ),
           ),

--- a/lib/views/tv/tvPlayerView.dart
+++ b/lib/views/tv/tvPlayerView.dart
@@ -6,6 +6,7 @@ import 'package:invidious/models/paginatedList.dart';
 import 'package:invidious/models/recommendedVideo.dart';
 import 'package:invidious/models/videoInList.dart';
 import 'package:invidious/utils.dart';
+import 'package:invidious/views/tv/tvButton.dart';
 import 'package:invidious/views/tv/tvHorizontalVideoList.dart';
 import 'package:invidious/views/tv/tvOverScan.dart';
 import 'package:invidious/views/tv/tvPlayerSettings.dart';
@@ -13,12 +14,15 @@ import 'package:invidious/views/video/player.dart';
 
 import '../../globals.dart';
 import '../../main.dart';
+import '../../models/baseVideo.dart';
+import '../../models/imageObject.dart';
 import '../../models/video.dart';
+import '../components/videoThumbnail.dart';
 
 class TvPlayerView extends StatelessWidget {
-  final Video video;
+  final List<BaseVideo> videos;
 
-  const TvPlayerView({Key? key, required this.video}) : super(key: key);
+  const TvPlayerView({Key? key, required this.videos}) : super(key: key);
 
   onVideoQueueSelected(BuildContext context, TvPlayerController _, VideoInList video) {
     _.playFromQueue(video);
@@ -33,175 +37,321 @@ class TvPlayerView extends StatelessWidget {
       data: ThemeData(useMaterial3: true, colorScheme: darkColorScheme),
       child: Scaffold(
         body: GetBuilder<TvPlayerController>(
-          init: TvPlayerController(videos: [video, ...video.recommendedVideos.map((e) => RecommendedVideo.toVideoInList(e)).toList()]),
-          builder: (_) => Focus(
-            autofocus: true,
-            onKeyEvent: (node, event) => _.handleRemoteEvents(node, event),
-            child: Stack(
-              children: [
-                VideoPlayer(
-                  video: video,
-                  miniPlayer: false,
-                  playNow: true,
-                  disableControls: true,
-                ),
-                Positioned(
-                  top: TvOverscan.vertical,
-                  right: TvOverscan.horizontal,
-                  child: AnimatedOpacity(
-                    opacity: _.buffering ? 1 : 0,
-                    duration: animationDuration,
-                    child: const SizedBox(
-                      width: 20,
-                      height: 20,
+          init: TvPlayerController(videos: videos),
+          builder: (_) => _.loading
+              ? Container(
+                  color: Colors.black,
+                  child: const Center(
+                    child: SizedBox(
+                      width: 50,
+                      height: 50,
                       child: CircularProgressIndicator(),
                     ),
                   ),
-                ),
-                Positioned(
-                    child: AnimatedOpacity(
-                  opacity: _.controlsOpacity,
-                  duration: animationDuration,
-                  child: Container(
-                      alignment: Alignment.topCenter,
-                      height: 250,
-                      decoration: BoxDecoration(
-                          gradient: LinearGradient(
-                        begin: Alignment.bottomCenter,
-                        end: Alignment.topCenter,
-                        colors: [
-                          Colors.black.withOpacity(0),
-                          Colors.black.withOpacity(0.6),
-                          Colors.black.withOpacity(0.7),
-                        ],
+                )
+              : Focus(
+                  autofocus: true,
+                  onKeyEvent: (node, event) => _.handleRemoteEvents(node, event),
+                  child: Stack(
+                    children: [
+                      VideoPlayer(
+                        video: _.currentlyPlaying,
+                        miniPlayer: false,
+                        playNow: true,
+                        disableControls: true,
+                      ),
+                      Positioned(
+                        top: 0,
+                        left: 0,
+                        right: 0,
+                        bottom: 0,
+                        child: AnimatedOpacity(
+                          opacity: _.controlsOpacity,
+                          duration: animationDuration,
+                          child: Container(
+                            decoration: BoxDecoration(
+                                gradient: LinearGradient(
+                                    begin: Alignment.topCenter, end: Alignment.bottomCenter, colors: [Colors.black.withOpacity(1), Colors.black.withOpacity(0), Colors.black.withOpacity(1)])),
+                          ),
+                        ),
+                      ),
+                      Positioned(
+                        top: TvOverscan.vertical,
+                        right: TvOverscan.horizontal,
+                        child: AnimatedOpacity(
+                          opacity: _.buffering ? 1 : 0,
+                          duration: animationDuration,
+                          child: const SizedBox(
+                            width: 20,
+                            height: 20,
+                            child: CircularProgressIndicator(),
+                          ),
+                        ),
+                      ),
+                      Positioned(
+                          child: TvOverscan(
+                        child: _.showSettings ? const TvPlayerSettings() : const SizedBox.shrink(),
                       )),
-                      child: TvOverscan(
-                        child: _.showSettings
-                            ? const TvPlayerSettings()
-                            : Column(
-                                mainAxisSize: MainAxisSize.min,
-                                crossAxisAlignment: CrossAxisAlignment.center,
-                                children: [
-                                  Text(
-                                    locals.pressDownToShowSettings,
-                                    style: TextStyle(fontSize: 20),
-                                  ),
-                                  const Icon(
-                                    Icons.expand_more,
-                                    size: 30,
-                                  ),
-                                ],
-                              ),
-                      )),
-                )),
-                Positioned(
-                  bottom: 0,
-                  left: 0,
-                  right: 0,
-                  child: AnimatedOpacity(
-                    opacity: _.controlsOpacity,
-                    duration: animationDuration,
-                    child: Container(
-                      alignment: Alignment.bottomCenter,
-                      height: 200,
-                      decoration: BoxDecoration(
-                          gradient: LinearGradient(
-                        begin: Alignment.bottomCenter,
-                        end: Alignment.topCenter,
-                        colors: [
-                          Colors.black.withOpacity(0.7),
-                          Colors.black.withOpacity(0),
-                        ],
-                      )),
-                      child: TvOverscan(
-                        child: Column(
-                          mainAxisAlignment: MainAxisAlignment.end,
-                          children: [
-                            video.liveNow
-                                ? const SizedBox.shrink()
-                                : Row(
-                                    mainAxisAlignment: MainAxisAlignment.end,
-                                    children: [
-                                      Text(
-                                        '${prettyDuration(_.currentPosition)} / ${prettyDuration(_.videoLength)}',
-                                        style: const TextStyle(color: Colors.white, fontSize: 24),
-                                      )
-                                    ],
-                                  ),
-                            Row(
-                              mainAxisAlignment: MainAxisAlignment.start,
-                              children: [
-                                Icon(
-                                  _.isPlaying ? Icons.pause : Icons.play_arrow,
-                                  size: 50,
-                                ),
-                                video.liveNow
-                                    ? Container(
-                                        decoration: BoxDecoration(
-                                          color: Colors.red,
-                                          borderRadius: BorderRadius.circular(30),
+                      Positioned(
+                          top: 0,
+                          left: 0,
+                          right: 0,
+                          child: _.showSettings
+                              ? SizedBox.shrink()
+                              : AnimatedOpacity(
+                                  opacity: _.controlsOpacity,
+                                  duration: animationDuration,
+                                  child: TvOverscan(
+                                    child: Column(
+                                      mainAxisSize: MainAxisSize.min,
+                                      crossAxisAlignment: CrossAxisAlignment.start,
+                                      children: [
+                                        Text(
+                                          _.currentlyPlaying.title,
+                                          style: textTheme.headlineLarge,
                                         ),
-                                        child: Padding(
-                                          padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 2),
+                                        Padding(
+                                          padding: const EdgeInsets.only(top: 16.0),
                                           child: Row(
-                                            mainAxisAlignment: MainAxisAlignment.end,
-                                            crossAxisAlignment: CrossAxisAlignment.center,
+                                            mainAxisSize: MainAxisSize.min,
                                             children: [
-                                              const Icon(
-                                                Icons.podcasts,
-                                                size: 15,
+                                              Thumbnail(
+                                                thumbnailUrl: ImageObject.getBestThumbnail(_.currentlyPlaying.authorThumbnails)?.url ?? '',
+                                                width: 40,
+                                                height: 40,
+                                                id: 'author-small-${_.currentlyPlaying.authorId}',
+                                                decoration: BoxDecoration(borderRadius: BorderRadius.circular(20)),
                                               ),
                                               Padding(
-                                                padding: const EdgeInsets.only(left: 8.0),
+                                                padding: const EdgeInsets.only(left: 8.0, right: 20),
                                                 child: Text(
-                                                  locals.streamIsLive,
-                                                  style: textTheme.bodyLarge,
+                                                  _.currentlyPlaying.author ?? '',
+                                                  style: textTheme.headlineSmall,
+                                                ),
+                                              )
+                                            ],
+                                          ),
+                                        )
+                                      ],
+                                    ),
+                                  ),
+                                )),
+                      Positioned(
+                        bottom: 0,
+                        left: 0,
+                        right: 0,
+                        child: AnimatedOpacity(
+                          opacity: _.controlsOpacity,
+                          duration: animationDuration,
+                          child: TvOverscan(
+                            child: Column(
+                              mainAxisAlignment: MainAxisAlignment.end,
+                              children: [
+                                _.currentlyPlaying.liveNow || _.showControls
+                                    ? const SizedBox.shrink()
+                                    : Row(
+                                        mainAxisAlignment: MainAxisAlignment.end,
+                                        children: [
+                                          Text(
+                                            '${prettyDuration(_.currentPosition)} / ${prettyDuration(_.videoLength)}',
+                                            style: const TextStyle(color: Colors.white, fontSize: 24),
+                                          )
+                                        ],
+                                      ),
+                                _.showControls
+                                    ? Padding(
+                                        padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 16),
+                                        child: FocusScope(
+                                          child: Row(
+                                            children: [
+                                              Padding(
+                                                padding: const EdgeInsets.only(right: 16.0),
+                                                child: TvButton(
+                                                  onPressed: (context) => _.togglePlayPause(),
+                                                  unfocusedColor: Colors.transparent,
+                                                  autofocus: true,
+                                                  child: Padding(
+                                                    padding: const EdgeInsets.all(8.0),
+                                                    child: Icon(
+                                                      _.isPlaying ? Icons.pause : Icons.play_arrow,
+                                                      size: 50,
+                                                    ),
+                                                  ),
+                                                ),
+                                              ),
+                                              Visibility(
+                                                visible: _.videos.length > 1,
+                                                child: Padding(
+                                                  padding: const EdgeInsets.only(right: 16.0),
+                                                  child: TvButton(
+                                                    onPressed: (context) => _.playPrevious(),
+                                                    unfocusedColor: Colors.transparent,
+                                                    child: const Padding(
+                                                      padding: EdgeInsets.all(8.0),
+                                                      child: Icon(
+                                                        Icons.skip_previous,
+                                                        size: 50,
+                                                      ),
+                                                    ),
+                                                  ),
+                                                ),
+                                              ),
+                                              Padding(
+                                                padding: const EdgeInsets.only(right: 16.0),
+                                                child: TvButton(
+                                                  unfocusedColor: Colors.transparent,
+                                                  onPressed: (context) => _.fastRewind(),
+                                                  child: const Padding(
+                                                    padding: EdgeInsets.all(8.0),
+                                                    child: Icon(
+                                                      Icons.fast_rewind,
+                                                      size: 50,
+                                                    ),
+                                                  ),
+                                                ),
+                                              ),
+                                              Padding(
+                                                padding: const EdgeInsets.only(right: 16.0),
+                                                child: TvButton(
+                                                  onPressed: (context) => _.fastForward(),
+                                                  unfocusedColor: Colors.transparent,
+                                                  child: const Padding(
+                                                    padding: EdgeInsets.all(8.0),
+                                                    child: Icon(
+                                                      Icons.fast_forward,
+                                                      size: 50,
+                                                    ),
+                                                  ),
+                                                ),
+                                              ),
+                                              Visibility(
+                                                visible: _.videos.length > 1,
+                                                child: TvButton(
+                                                  onPressed: (context) => _.playNext(),
+                                                  unfocusedColor: Colors.transparent,
+                                                  child: const Padding(
+                                                    padding: EdgeInsets.all(8.0),
+                                                    child: Icon(
+                                                      Icons.skip_next,
+                                                      size: 50,
+                                                    ),
+                                                  ),
+                                                ),
+                                              ),
+                                              Expanded(child: Container()),
+                                              Padding(
+                                                padding: const EdgeInsets.only(right: 16.0),
+                                                child: TvButton(
+                                                  onPressed: (context) => _.displayQueue(),
+                                                  unfocusedColor: Colors.transparent,
+                                                  child: const Padding(
+                                                    padding: EdgeInsets.all(8.0),
+                                                    child: Icon(
+                                                      Icons.video_library,
+                                                      size: 30,
+                                                    ),
+                                                  ),
+                                                ),
+                                              ),
+                                              Padding(
+                                                padding: const EdgeInsets.only(right: 16.0),
+                                                child: TvButton(
+                                                  onPressed: (context) => _.displaySettings(),
+                                                  unfocusedColor: Colors.transparent,
+                                                  child: const Padding(
+                                                    padding: EdgeInsets.all(8.0),
+                                                    child: Icon(
+                                                      Icons.settings,
+                                                      size: 30,
+                                                    ),
+                                                  ),
                                                 ),
                                               ),
                                             ],
                                           ),
                                         ),
                                       )
-                                    : Expanded(
-                                        child: Container(
-                                            color: Colors.black.withOpacity(0.5),
-                                            child: AnimatedFractionallySizedBox(
-                                              alignment: Alignment.centerLeft,
-                                              duration: animationDuration,
-                                              widthFactor: _.progress,
-                                              child: Container(
-                                                height: 4,
-                                                color: Colors.white,
+                                    : const SizedBox.shrink(),
+                                Row(
+                                  mainAxisAlignment: MainAxisAlignment.start,
+                                  children: [
+                                    _.currentlyPlaying.liveNow
+                                        ? Container(
+                                            decoration: BoxDecoration(
+                                              color: Colors.red,
+                                              borderRadius: BorderRadius.circular(30),
+                                            ),
+                                            child: Padding(
+                                              padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 2),
+                                              child: Row(
+                                                mainAxisAlignment: MainAxisAlignment.end,
+                                                crossAxisAlignment: CrossAxisAlignment.center,
+                                                children: [
+                                                  const Icon(
+                                                    Icons.podcasts,
+                                                    size: 15,
+                                                  ),
+                                                  Padding(
+                                                    padding: const EdgeInsets.only(left: 8.0),
+                                                    child: Text(
+                                                      locals.streamIsLive,
+                                                      style: textTheme.bodyLarge,
+                                                    ),
+                                                  ),
+                                                ],
                                               ),
-                                            )))
+                                            ),
+                                          )
+                                        : Expanded(
+                                            child: _.progress >= 0
+                                                ? Container(
+                                                    decoration: BoxDecoration(color: Colors.black.withOpacity(0.5), borderRadius: BorderRadius.circular(5)),
+                                                    child: AnimatedFractionallySizedBox(
+                                                      alignment: Alignment.centerLeft,
+                                                      duration: animationDuration,
+                                                      widthFactor: _.progress,
+                                                      child: Container(
+                                                        height: 8,
+                                                        decoration: BoxDecoration(color: Colors.white, borderRadius: BorderRadius.circular(5)),
+                                                      ),
+                                                    ))
+                                                : const SizedBox.shrink())
+                                  ],
+                                )
                               ],
                             ),
-                            const Icon(
-                              Icons.expand_less,
-                              size: 30,
-                            ),
-                            Text('Up to show queue'),
-                          ],
+                          ),
                         ),
                       ),
-                    ),
+                      Positioned(
+                          left: 0,
+                          bottom: 50,
+                          right: 0,
+                          child: AnimatedSwitcher(
+                              duration: animationDuration,
+                              child: _.showQueue
+                                  ? TvOverscan(
+                                      child: FocusScope(
+                                      autofocus: true,
+                                      child: Column(
+                                        crossAxisAlignment: CrossAxisAlignment.start,
+                                        children: [
+                                          Text(
+                                            locals.videoQueue,
+                                            style: textTheme.titleLarge,
+                                          ),
+                                          TvHorizontalVideoList(
+                                              onSelect: (ctx, video) => onVideoQueueSelected(ctx, _, video),
+                                              paginatedVideoList: FixedItemList(videos
+                                                  .map((e) => VideoInList(e.title, e.videoId, e.lengthSeconds, null, e.author, e.authorId, e.authorUrl, null, null, e.videoThumbnails))
+                                                  .toList())),
+                                        ],
+                                      ),
+                                    ))
+                                  : const SizedBox.shrink()))
+                    ],
                   ),
                 ),
-                Positioned(
-                    left: 0,
-                    bottom: 0,
-                    right: 0,
-                    child: AnimatedSwitcher(
-                        duration: animationDuration,
-                        child: _.showQueue
-                            ? TvOverscan(
-                                child: TvHorizontalVideoList(
-                                    onSelect: (ctx, video) => onVideoQueueSelected(ctx, _, video),
-                                    paginatedVideoList: FixedItemList(video.recommendedVideos.map((e) => RecommendedVideo.toVideoInList(e)).toList())))
-                            : const SizedBox.shrink()))
-              ],
-            ),
-          ),
         ),
       ),
     );

--- a/lib/views/tv/tvPlayerView.dart
+++ b/lib/views/tv/tvPlayerView.dart
@@ -2,12 +2,17 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:get/get.dart';
 import 'package:invidious/controllers/tvPlayerController.dart';
+import 'package:invidious/models/paginatedList.dart';
+import 'package:invidious/models/recommendedVideo.dart';
+import 'package:invidious/models/videoInList.dart';
 import 'package:invidious/utils.dart';
+import 'package:invidious/views/tv/tvHorizontalVideoList.dart';
 import 'package:invidious/views/tv/tvOverScan.dart';
 import 'package:invidious/views/tv/tvPlayerSettings.dart';
 import 'package:invidious/views/video/player.dart';
 
 import '../../globals.dart';
+import '../../main.dart';
 import '../../models/video.dart';
 
 class TvPlayerView extends StatelessWidget {
@@ -20,158 +25,166 @@ class TvPlayerView extends StatelessWidget {
     ColorScheme colors = Theme.of(context).colorScheme;
     TextTheme textTheme = Theme.of(context).textTheme;
     var locals = AppLocalizations.of(context)!;
-    return Scaffold(
-      body: GetBuilder<TvPlayerController>(
-        init: TvPlayerController(),
-        builder: (_) => Focus(
-          autofocus: true,
-          onKeyEvent: (node, event) => _.handleRemoteEvents(node, event),
-          child: Stack(
-            children: [
-              VideoPlayer(
-                video: video,
-                miniPlayer: false,
-                playNow: true,
-                disableControls: true,
-              ),
-              Positioned(
-                top: TvOverscan.vertical,
-                right: TvOverscan.horizontal,
-                child: AnimatedOpacity(
-                  opacity: _.buffering ? 1 : 0,
-                  duration: animationDuration,
-                  child: const SizedBox(
-                    width: 20,
-                    height: 20,
-                    child: CircularProgressIndicator(),
-                  ),
+    return Theme(
+      data: ThemeData(useMaterial3: true, colorScheme: darkColorScheme),
+      child: Scaffold(
+        body: GetBuilder<TvPlayerController>(
+          init: TvPlayerController(),
+          builder: (_) => Focus(
+            autofocus: true,
+            onKeyEvent: (node, event) => _.handleRemoteEvents(node, event),
+            child: Stack(
+              children: [
+                VideoPlayer(
+                  video: video,
+                  miniPlayer: false,
+                  playNow: true,
+                  disableControls: true,
                 ),
-              ),
-              Positioned(
+                Positioned(
+                  top: TvOverscan.vertical,
+                  right: TvOverscan.horizontal,
                   child: AnimatedOpacity(
-                opacity: _.controlsOpacity,
-                duration: animationDuration,
-                child: Container(
-                    alignment: Alignment.topCenter,
-                    height: 250,
-                    decoration: BoxDecoration(
-                        gradient: LinearGradient(
-                      begin: Alignment.bottomCenter,
-                      end: Alignment.topCenter,
-                      colors: [
-                        Colors.black.withOpacity(0),
-                        Colors.black.withOpacity(0.6),
-                        Colors.black.withOpacity(0.7),
-                      ],
-                    )),
-                    child: TvOverscan(
-                      child: _.showSettings
-                          ? const TvPlayerSettings()
-                          : Column(
-                              mainAxisSize: MainAxisSize.min,
-                              crossAxisAlignment: CrossAxisAlignment.center,
-                              children: [
-                                Text(
-                                  locals.pressDownToShowSettings,
-                                  style: TextStyle(fontSize: 20),
-                                ),
-                                const Icon(
-                                  Icons.expand_more,
-                                  size: 30,
-                                ),
-                              ],
-                            ),
-                    )),
-              )),
-              Positioned(
-                bottom: 0,
-                left: 0,
-                right: 0,
-                child: AnimatedOpacity(
-                  opacity: _.controlsOpacity,
-                  duration: animationDuration,
-                  child: Container(
-                    alignment: Alignment.bottomCenter,
-                    height: 150,
-                    decoration: BoxDecoration(
-                        gradient: LinearGradient(
-                      begin: Alignment.bottomCenter,
-                      end: Alignment.topCenter,
-                      colors: [
-                        Colors.black.withOpacity(0.7),
-                        Colors.black.withOpacity(0),
-                      ],
-                    )),
-                    child: TvOverscan(
-                      child: Column(
-                        mainAxisAlignment: MainAxisAlignment.end,
-                        children: [
-                          video.liveNow
-                              ? const SizedBox.shrink()
-                              : Row(
-                                  mainAxisAlignment: MainAxisAlignment.end,
-                                  children: [
-                                    Text(
-                                      '${prettyDuration(_.currentPosition)} / ${prettyDuration(_.videoLength)}',
-                                      style: const TextStyle(color: Colors.white, fontSize: 24),
-                                    )
-                                  ],
-                                ),
-                          Row(
-                            mainAxisAlignment: MainAxisAlignment.start,
-                            children: [
-                              Icon(
-                                _.isPlaying ? Icons.pause : Icons.play_arrow,
-                                size: 50,
-                              ),
-                              video.liveNow
-                                  ? Container(
-                                      decoration: BoxDecoration(
-                                        color: Colors.red,
-                                        borderRadius: BorderRadius.circular(30),
-                                      ),
-                                      child: Padding(
-                                        padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 2),
-                                        child: Row(
-                                          mainAxisAlignment: MainAxisAlignment.end,
-                                          crossAxisAlignment: CrossAxisAlignment.center,
-                                          children: [
-                                            const Icon(
-                                              Icons.podcasts,
-                                              size: 15,
-                                            ),
-                                            Padding(
-                                              padding: const EdgeInsets.only(left: 8.0),
-                                              child: Text(
-                                                locals.streamIsLive,
-                                                style: textTheme.bodyLarge,
-                                              ),
-                                            ),
-                                          ],
-                                        ),
-                                      ),
-                                    )
-                                  : Expanded(
-                                      child: Container(
-                                          color: Colors.black.withOpacity(0.5),
-                                          child: AnimatedFractionallySizedBox(
-                                            alignment: Alignment.centerLeft,
-                                            duration: animationDuration,
-                                            widthFactor: _.progress,
-                                            child: Container(
-                                              height: 4,
-                                              color: Colors.white,
-                                            ),
-                                          )))
-                            ],
-                          )
-                        ],
-                      ),
+                    opacity: _.buffering ? 1 : 0,
+                    duration: animationDuration,
+                    child: const SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(),
                     ),
                   ),
                 ),
-              )
-            ],
+                Positioned(
+                    child: AnimatedOpacity(
+                  opacity: _.controlsOpacity,
+                  duration: animationDuration,
+                  child: Container(
+                      alignment: Alignment.topCenter,
+                      height: 250,
+                      decoration: BoxDecoration(
+                          gradient: LinearGradient(
+                        begin: Alignment.bottomCenter,
+                        end: Alignment.topCenter,
+                        colors: [
+                          Colors.black.withOpacity(0),
+                          Colors.black.withOpacity(0.6),
+                          Colors.black.withOpacity(0.7),
+                        ],
+                      )),
+                      child: TvOverscan(
+                        child: _.showSettings
+                            ? const TvPlayerSettings()
+                            : Column(
+                                mainAxisSize: MainAxisSize.min,
+                                crossAxisAlignment: CrossAxisAlignment.center,
+                                children: [
+                                  Text(
+                                    locals.pressDownToShowSettings,
+                                    style: TextStyle(fontSize: 20),
+                                  ),
+                                  const Icon(
+                                    Icons.expand_more,
+                                    size: 30,
+                                  ),
+                                ],
+                              ),
+                      )),
+                )),
+                Positioned(
+                  bottom: 0,
+                  left: 0,
+                  right: 0,
+                  child: AnimatedOpacity(
+                    opacity: _.controlsOpacity,
+                    duration: animationDuration,
+                    child: Container(
+                      alignment: Alignment.bottomCenter,
+                      height: 200,
+                      decoration: BoxDecoration(
+                          gradient: LinearGradient(
+                        begin: Alignment.bottomCenter,
+                        end: Alignment.topCenter,
+                        colors: [
+                          Colors.black.withOpacity(0.7),
+                          Colors.black.withOpacity(0),
+                        ],
+                      )),
+                      child: TvOverscan(
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.end,
+                          children: [
+                            video.liveNow
+                                ? const SizedBox.shrink()
+                                : Row(
+                                    mainAxisAlignment: MainAxisAlignment.end,
+                                    children: [
+                                      Text(
+                                        '${prettyDuration(_.currentPosition)} / ${prettyDuration(_.videoLength)}',
+                                        style: const TextStyle(color: Colors.white, fontSize: 24),
+                                      )
+                                    ],
+                                  ),
+                            Row(
+                              mainAxisAlignment: MainAxisAlignment.start,
+                              children: [
+                                Icon(
+                                  _.isPlaying ? Icons.pause : Icons.play_arrow,
+                                  size: 50,
+                                ),
+                                video.liveNow
+                                    ? Container(
+                                        decoration: BoxDecoration(
+                                          color: Colors.red,
+                                          borderRadius: BorderRadius.circular(30),
+                                        ),
+                                        child: Padding(
+                                          padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 2),
+                                          child: Row(
+                                            mainAxisAlignment: MainAxisAlignment.end,
+                                            crossAxisAlignment: CrossAxisAlignment.center,
+                                            children: [
+                                              const Icon(
+                                                Icons.podcasts,
+                                                size: 15,
+                                              ),
+                                              Padding(
+                                                padding: const EdgeInsets.only(left: 8.0),
+                                                child: Text(
+                                                  locals.streamIsLive,
+                                                  style: textTheme.bodyLarge,
+                                                ),
+                                              ),
+                                            ],
+                                          ),
+                                        ),
+                                      )
+                                    : Expanded(
+                                        child: Container(
+                                            color: Colors.black.withOpacity(0.5),
+                                            child: AnimatedFractionallySizedBox(
+                                              alignment: Alignment.centerLeft,
+                                              duration: animationDuration,
+                                              widthFactor: _.progress,
+                                              child: Container(
+                                                height: 4,
+                                                color: Colors.white,
+                                              ),
+                                            )))
+                              ],
+                            ),
+                            const Icon(
+                              Icons.expand_less,
+                              size: 30,
+                            ),
+                            TvHorizontalVideoList(paginatedVideoList: FixedItemList(video.recommendedVideos.map((e) => RecommendedVideo.toVideoInList(e)).toList()))
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                )
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/views/tv/tvPlayerView.dart
+++ b/lib/views/tv/tvPlayerView.dart
@@ -20,6 +20,10 @@ class TvPlayerView extends StatelessWidget {
 
   const TvPlayerView({Key? key, required this.video}) : super(key: key);
 
+  onVideoQueueSelected(BuildContext context, TvPlayerController _, VideoInList video) {
+    _.playFromQueue(video);
+  }
+
   @override
   Widget build(BuildContext context) {
     ColorScheme colors = Theme.of(context).colorScheme;
@@ -29,7 +33,7 @@ class TvPlayerView extends StatelessWidget {
       data: ThemeData(useMaterial3: true, colorScheme: darkColorScheme),
       child: Scaffold(
         body: GetBuilder<TvPlayerController>(
-          init: TvPlayerController(),
+          init: TvPlayerController(videos: [video, ...video.recommendedVideos.map((e) => RecommendedVideo.toVideoInList(e)).toList()]),
           builder: (_) => Focus(
             autofocus: true,
             onKeyEvent: (node, event) => _.handleRemoteEvents(node, event),
@@ -176,13 +180,25 @@ class TvPlayerView extends StatelessWidget {
                               Icons.expand_less,
                               size: 30,
                             ),
-                            TvHorizontalVideoList(paginatedVideoList: FixedItemList(video.recommendedVideos.map((e) => RecommendedVideo.toVideoInList(e)).toList()))
+                            Text('Up to show queue'),
                           ],
                         ),
                       ),
                     ),
                   ),
-                )
+                ),
+                Positioned(
+                    left: 0,
+                    bottom: 0,
+                    right: 0,
+                    child: AnimatedSwitcher(
+                        duration: animationDuration,
+                        child: _.showQueue
+                            ? TvOverscan(
+                                child: TvHorizontalVideoList(
+                                    onSelect: (ctx, video) => onVideoQueueSelected(ctx, _, video),
+                                    paginatedVideoList: FixedItemList(video.recommendedVideos.map((e) => RecommendedVideo.toVideoInList(e)).toList())))
+                            : const SizedBox.shrink()))
               ],
             ),
           ),

--- a/lib/views/tv/tvPlaylistView.dart
+++ b/lib/views/tv/tvPlaylistView.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:get/get.dart';
+import 'package:invidious/controllers/playlistController.dart';
+import 'package:invidious/views/playlistView.dart';
+import 'package:invidious/views/tv/tvButton.dart';
+import 'package:invidious/views/tv/tvOverScan.dart';
+import 'package:invidious/views/tv/tvPlayerView.dart';
+import 'package:invidious/views/tv/tvVideoItem.dart';
+
+class TvPlaylistView extends PlaylistView {
+  TvPlaylistView({required super.playlist, required super.canDeleteVideos});
+
+  playPlaylist(BuildContext context, PlaylistController _) {
+    Navigator.of(context).push(MaterialPageRoute(builder: (ctx) => TvPlayerView(videos: _.playlist.videos)));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    var locals = AppLocalizations.of(context)!;
+    TextTheme textTheme = Theme.of(context).textTheme;
+    return Scaffold(
+      body: TvOverscan(
+        child: GetBuilder<PlaylistController>(
+          global: false,
+          init: PlaylistController(playlist: playlist, playlistItemHeight: 0),
+          builder: (_) {
+            return _.loading
+                ? Center(
+                    child: SizedBox(
+                      width: 50,
+                      height: 50,
+                      child: CircularProgressIndicator(value: _.loadingProgress,),
+                    ),
+                  )
+                : SingleChildScrollView(
+                    controller: _.scrollController,
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.start,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          _.playlist.title,
+                          style: textTheme.headlineLarge,
+                        ),
+                        Row(
+                          crossAxisAlignment: CrossAxisAlignment.end,
+                          children: [
+                            SizedBox(
+                              height: 200,
+                              child: AspectRatio(
+                                aspectRatio: 16 / 9,
+                                child: Stack(
+                                  children: buildThumbnails(context, _),
+                                ),
+                              ),
+                            ),
+                            Padding(
+                              padding: const EdgeInsets.only(left: 32.0),
+                              child: TvButton(
+                                autofocus: true,
+                                onFocusChanged: (focus) {
+                                  if (focus) {
+                                    _.scrollToTop();
+                                  }
+                                },
+                                onPressed: (context) => playPlaylist(context, _),
+                                child: const Padding(
+                                  padding: EdgeInsets.all(15.0),
+                                  child: Icon(
+                                    Icons.play_arrow,
+                                    size: 50,
+                                  ),
+                                ),
+                              ),
+                            )
+                          ],
+                        ),
+                        Padding(
+                          padding: const EdgeInsets.symmetric(vertical: 16.0),
+                          child: Text(
+                            locals.videos,
+                            style: textTheme.titleLarge,
+                          ),
+                        ),
+                        GridView.count(
+                          physics: const NeverScrollableScrollPhysics(),
+                          shrinkWrap: true,
+                          controller: _.scrollController,
+                          childAspectRatio: 16 / 13,
+                          crossAxisCount: 3,
+                          children: _.playlist.videos.map((e) => TvVideoItem(video: e, autoFocus: false)).toList(),
+                        )
+                      ],
+                    ),
+                  );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/tv/tvSearch.dart
+++ b/lib/views/tv/tvSearch.dart
@@ -50,6 +50,8 @@ class TvSearch extends StatelessWidget {
     TextTheme textTheme = Theme.of(context).textTheme;
     var locals = AppLocalizations.of(context)!;
 
+    var colors = Theme.of(context).colorScheme;
+
     return Scaffold(
       body: TvOverscan(
         child: DefaultTextStyle(
@@ -158,23 +160,17 @@ class TvSearch extends StatelessWidget {
                                       ),
                                       Visibility(
                                         visible: _.playlists.isNotEmpty ?? false,
-                                        child: SizedBox(
-                                          height: 200,
-                                          child: TvHorizontalPaginatedListView<Playlist>(
-                                            paginatedList: PlaylistSearchPaginatedList<Playlist>(
-                                                getFromResults: (res) => res.playlists, sortBy: _.sortBy, query: _.queryController.value.text, items: _.playlists, type: SearchType.playlist
-                                            ),
-                                            startItems: _.playlists,
-                                            itemBuilder: (e) => Padding(
+                                        child: TvHorizontalItemList<Playlist>(
+                                          paginatedList: SearchPaginatedList<Playlist>(
+                                                getFromResults: (res) => res.playlists, sortBy: _.sortBy, query: _.queryController.value.text, items: _.playlists, type: SearchType.playlist),
+                                          buildItem: (context, index, item) => Padding(
                                               padding: const EdgeInsets.all(8.0),
                                               child: PlaylistItem(
-                                                  playlist: e,
-                                                  canDeleteVideos: false,
-                                                  isTv: true,
-                                                  cameFromSearch: true,
-                                              )
-                                            ),
-                                          ),
+                                                playlist: item,
+                                                canDeleteVideos: false,
+                                                isTv: true,
+                                                // cameFromSearch: true,
+                                              )),
                                         ),
                                       ),
                                     ],

--- a/lib/views/tv/tvSearch.dart
+++ b/lib/views/tv/tvSearch.dart
@@ -10,6 +10,7 @@ import 'package:invidious/views/tv/tvChannelView.dart';
 import 'package:invidious/views/tv/tvHorizontalPaginatedListView.dart';
 import 'package:invidious/views/tv/tvHorizontalVideoList.dart';
 import 'package:invidious/views/tv/tvOverScan.dart';
+import 'package:invidious/views/tv/tvTextField.dart';
 
 import '../../controllers/searchController.dart';
 import '../../controllers/tvSearchController.dart';
@@ -63,7 +64,8 @@ class TvSearch extends StatelessWidget {
                   locals.search,
                   style: textTheme.titleLarge,
                 ),
-                TextField(
+                TvTextField(
+                  leading: Icon(Icons.search,color: colors.secondary,),
                   controller: _.queryController,
                   autofocus: true,
                   autocorrect: true,
@@ -74,7 +76,7 @@ class TvSearch extends StatelessWidget {
                 Expanded(
                   child: Padding(
                     padding: const EdgeInsets.only(top: 20),
-                    child: FocusScope(
+                    child: _.showResults ? FocusScope(
                       onKeyEvent: _.handleResultScopeKeyEvent,
                       canRequestFocus: true,
                       child: Row(
@@ -180,7 +182,7 @@ class TvSearch extends StatelessWidget {
                           ))
                         ],
                       ),
-                    ),
+                    ): const SizedBox.shrink(),
                   ),
                 )
               ],

--- a/lib/views/tv/tvSubscribeButton.dart
+++ b/lib/views/tv/tvSubscribeButton.dart
@@ -8,8 +8,9 @@ class TvSubscribeButton extends StatelessWidget {
   final String channelId;
   final String subCount;
   final bool? autoFocus;
+  final Function(bool focus)? onFocusChanged;
 
-  const TvSubscribeButton({Key? key, required this.channelId, required this.subCount, this.autoFocus}) : super(key: key);
+  const TvSubscribeButton({Key? key, required this.channelId, required this.subCount, this.autoFocus, this.onFocusChanged}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -24,6 +25,7 @@ class TvSubscribeButton extends StatelessWidget {
             padding: const EdgeInsets.symmetric(vertical: 16.0),
             child: TvButton(
               autofocus: autoFocus,
+              onFocusChanged: onFocusChanged,
               focusedColor: colors.secondaryContainer,
               unfocusedColor: colors.background.withOpacity(0.5),
               onPressed: (context) => _.isLoggedIn ? _.toggleSubscription() : null,

--- a/lib/views/tv/tvTextField.dart
+++ b/lib/views/tv/tvTextField.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:invidious/globals.dart';
 import 'package:invidious/main.dart';
 import 'package:invidious/utils.dart';
 import 'package:invidious/views/tv/tvOverScan.dart';
@@ -64,19 +65,21 @@ class TvTextField extends StatelessWidget {
 
         return Padding(
           padding: const EdgeInsets.all(8.0),
-          child: Container(
-            decoration:
-                BoxDecoration(color: hasFocus ? colors.secondaryContainer : colors.background, border: Border.all(color: colors.secondaryContainer, width: 2), borderRadius: BorderRadius.circular(10)),
+          child: AnimatedContainer(
+            duration: animationDuration ~/ 2,
+            decoration: BoxDecoration(color: hasFocus ? colors.secondaryContainer : colors.background, borderRadius: hasFocus ? BorderRadius.circular(10) : null),
             child: Padding(
               padding: const EdgeInsets.all(8.0),
               child: Row(
                 children: [
                   leading ?? const SizedBox.shrink(),
                   Expanded(
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 8.0),
-                      child: showLabel ? decoration!.label! : Text((obscureText ?? false) ? "************" : controller.text),
-                    ),
+                    child: Container(
+                        decoration: BoxDecoration(border: Border(bottom: BorderSide(width: 2, color: colors.secondaryContainer))),
+                        child: Padding(
+                          padding: const EdgeInsets.all(8.0),
+                          child: showLabel ? decoration!.label! : Text((obscureText ?? false) ? "************" : controller.text),
+                        )),
                   ),
                   trailing ?? const SizedBox.shrink()
                 ],

--- a/lib/views/tv/tvTextField.dart
+++ b/lib/views/tv/tvTextField.dart
@@ -1,0 +1,136 @@
+import 'package:flutter/material.dart';
+import 'package:invidious/main.dart';
+import 'package:invidious/utils.dart';
+import 'package:invidious/views/tv/tvOverScan.dart';
+
+class TvTextField extends StatelessWidget {
+  final TextEditingController controller;
+  final bool? autofocus;
+  final bool? autocorrect;
+  final FocusNode? focusNode;
+  final ValueChanged<String>? onSubmitted;
+  final TextInputAction? textInputAction;
+  final Function(bool focus)? onFocusChanged;
+  final Widget? leading;
+  final Widget? trailing;
+  final bool? obscureText;
+  final Iterable<String>? autofillHints;
+  final InputDecoration? decoration;
+
+  const TvTextField(
+      {Key? key,
+      required this.controller,
+      this.autofocus,
+      this.autocorrect,
+      this.focusNode,
+      this.onSubmitted,
+      this.textInputAction,
+      this.onFocusChanged,
+      this.leading,
+      this.trailing,
+      this.obscureText,
+      this.autofillHints,
+      this.decoration})
+      : super(key: key);
+
+  openTextField(BuildContext context) {
+    Navigator.of(context).push(MaterialPageRoute(
+        builder: (context) => TvTextFieldFiller(
+              controller: controller,
+              autocorrect: autocorrect,
+              autofocus: autofocus,
+              onSubmitted: onSubmitted,
+              textInputAction: textInputAction,
+              obscureText: obscureText,
+              autofillHints: autofillHints,
+              decoration: decoration,
+            )));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    ColorScheme colors = Theme.of(context).colorScheme;
+
+    return Focus(
+      autofocus: autofocus ?? false,
+      onFocusChange: onFocusChanged,
+      focusNode: focusNode,
+      onKeyEvent: (node, event) => onTvSelect(event, context, (context) => openTextField(context)),
+      child: Builder(builder: (ctx) {
+        bool hasFocus = Focus.of(ctx).hasFocus;
+        print(hasFocus);
+
+        bool showLabel = controller.text.isEmpty && decoration?.label != null;
+
+        return Container(
+          decoration:
+              BoxDecoration(color: hasFocus ? colors.secondaryContainer : colors.background, border: Border.all(color: colors.secondaryContainer, width: 2), borderRadius: BorderRadius.circular(10)),
+          child: Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Row(
+              children: [
+                leading ?? const SizedBox.shrink(),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                  child: Expanded(child: showLabel ? decoration!.label! : Text((obscureText ?? false) ? "************" : controller.text)),
+                ),
+                trailing ?? const SizedBox.shrink()
+              ],
+            ),
+          ),
+        );
+      }),
+    );
+  }
+}
+
+class TvTextFieldFiller extends StatelessWidget {
+  final TextEditingController controller;
+  final bool? autofocus;
+  final bool? autocorrect;
+  final FocusNode? focusNode;
+  final ValueChanged<String>? onSubmitted;
+  final TextInputAction? textInputAction;
+  final bool? obscureText;
+  final Iterable<String>? autofillHints;
+  final InputDecoration? decoration;
+
+  const TvTextFieldFiller(
+      {Key? key, required this.controller, this.autofocus, this.autocorrect, this.focusNode, this.onSubmitted, this.textInputAction, this.obscureText, this.autofillHints, this.decoration})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    TextTheme textTheme = Theme.of(context).textTheme;
+    return Scaffold(
+      body: TvOverscan(
+        child: DefaultTextStyle(
+          style: textTheme.bodyLarge!,
+          child: Column(
+            children: [
+              Expanded(
+                  child: Container(
+                alignment: Alignment.center,
+                child: TextField(
+                  autofocus: true,
+                  autocorrect: autocorrect ?? true,
+                  controller: controller,
+                  onSubmitted: (value) {
+                    if (onSubmitted != null) {
+                      onSubmitted!(value);
+                    }
+                    Navigator.of(context).pop();
+                  },
+                  textInputAction: textInputAction,
+                  autofillHints: autofillHints,
+                  decoration: decoration ?? const InputDecoration(),
+                  obscureText: obscureText ?? false,
+                ),
+              ))
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/tv/tvTextField.dart
+++ b/lib/views/tv/tvTextField.dart
@@ -62,20 +62,25 @@ class TvTextField extends StatelessWidget {
 
         bool showLabel = controller.text.isEmpty && decoration?.label != null;
 
-        return Container(
-          decoration:
-              BoxDecoration(color: hasFocus ? colors.secondaryContainer : colors.background, border: Border.all(color: colors.secondaryContainer, width: 2), borderRadius: BorderRadius.circular(10)),
-          child: Padding(
-            padding: const EdgeInsets.all(8.0),
-            child: Row(
-              children: [
-                leading ?? const SizedBox.shrink(),
-                Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 8.0),
-                  child: Expanded(child: showLabel ? decoration!.label! : Text((obscureText ?? false) ? "************" : controller.text)),
-                ),
-                trailing ?? const SizedBox.shrink()
-              ],
+        return Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: Container(
+            decoration:
+                BoxDecoration(color: hasFocus ? colors.secondaryContainer : colors.background, border: Border.all(color: colors.secondaryContainer, width: 2), borderRadius: BorderRadius.circular(10)),
+            child: Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: Row(
+                children: [
+                  leading ?? const SizedBox.shrink(),
+                  Expanded(
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                      child: showLabel ? decoration!.label! : Text((obscureText ?? false) ? "************" : controller.text),
+                    ),
+                  ),
+                  trailing ?? const SizedBox.shrink()
+                ],
+              ),
             ),
           ),
         );

--- a/lib/views/tv/tvVideoGridView.dart
+++ b/lib/views/tv/tvVideoGridView.dart
@@ -12,9 +12,8 @@ class TvGridView extends StatelessWidget {
   final PaginatedList<VideoInList> paginatedVideoList;
   final String? tags;
   final String title;
-  final bool shouldRefetch;
 
-  const TvGridView({Key? key, required this.paginatedVideoList, this.tags, required this.title, this.shouldRefetch = false}) : super(key: key);
+  const TvGridView({Key? key, required this.paginatedVideoList, this.tags, required this.title }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -23,7 +22,7 @@ class TvGridView extends StatelessWidget {
         child: GetBuilder<VideoListController>(
             global: tags != null,
             tag: tags,
-            init: VideoListController(videoList: paginatedVideoList, shouldRefetch: shouldRefetch),
+            init: VideoListController(videoList: paginatedVideoList),
             builder: (_) {
               return Column(
                 children: [
@@ -46,7 +45,7 @@ class TvGridView extends StatelessWidget {
                     controller: _.scrollController,
                     childAspectRatio: 16 / 13,
                     crossAxisCount: 3,
-                    children: _.videos.map((e) => TvVideoItem(video: e, autoFocus: false)).toList(),
+                    children: _.items.map((e) => TvVideoItem(video: e, autoFocus: false)).toList(),
                   ))
                 ],
               );

--- a/lib/views/tv/tvVideoItem.dart
+++ b/lib/views/tv/tvVideoItem.dart
@@ -16,11 +16,12 @@ class TvVideoItem extends StatelessWidget {
   const TvVideoItem({Key? key, required this.video, required this.autoFocus, this.onSelect}) : super(key: key);
 
   openVideo(BuildContext context, VideoInList e, FocusNode node, KeyEvent event) {
-    if (onSelect != null) {
-      onSelect!(context, e);
-      return KeyEventResult.handled;
-    } else if (event is KeyUpEvent && (event.logicalKey == LogicalKeyboardKey.enter || event.logicalKey == LogicalKeyboardKey.select)) {
-      Navigator.of(context).push(MaterialPageRoute(builder: (ctx) => TvVideoView(videoId: e.videoId)));
+    if (event is KeyUpEvent && (event.logicalKey == LogicalKeyboardKey.enter || event.logicalKey == LogicalKeyboardKey.select)) {
+      if (onSelect != null) {
+        onSelect!(context, e);
+      } else {
+        Navigator.of(context).push(MaterialPageRoute(builder: (ctx) => TvVideoView(videoId: e.videoId)));
+      }
       return KeyEventResult.handled;
     }
     return KeyEventResult.ignored;

--- a/lib/views/tv/tvVideoItem.dart
+++ b/lib/views/tv/tvVideoItem.dart
@@ -11,10 +11,15 @@ import '../components/videoThumbnail.dart';
 class TvVideoItem extends StatelessWidget {
   final VideoInList video;
   final bool autoFocus;
-  const TvVideoItem({Key? key, required this.video, required this.autoFocus}) : super(key: key);
+  final Function(BuildContext context, VideoInList video)? onSelect;
+
+  const TvVideoItem({Key? key, required this.video, required this.autoFocus, this.onSelect}) : super(key: key);
 
   openVideo(BuildContext context, VideoInList e, FocusNode node, KeyEvent event) {
-    if (event is KeyUpEvent && (event.logicalKey == LogicalKeyboardKey.enter || event.logicalKey == LogicalKeyboardKey.select)) {
+    if (onSelect != null) {
+      onSelect!(context, e);
+      return KeyEventResult.handled;
+    } else if (event is KeyUpEvent && (event.logicalKey == LogicalKeyboardKey.enter || event.logicalKey == LogicalKeyboardKey.select)) {
       Navigator.of(context).push(MaterialPageRoute(builder: (ctx) => TvVideoView(videoId: e.videoId)));
       return KeyEventResult.handled;
     }
@@ -30,7 +35,7 @@ class TvVideoItem extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsets.only(right: 8.0),
         child: Focus(
-          // onFocusChange: (value) => _.focusChanged(value, index),
+            // onFocusChange: (value) => _.focusChanged(value, index),
             onKeyEvent: (node, event) => openVideo(context, video, node, event),
             autofocus: autoFocus,
             child: Builder(builder: (ctx) {
@@ -39,8 +44,8 @@ class TvVideoItem extends StatelessWidget {
               return GestureDetector(
                 child: AnimatedScale(
                   curve: Curves.easeInOutQuad,
-                  duration: animationDuration ~/2,
-                  scale: hasFocus ? 1: 0.9,
+                  duration: animationDuration ~/ 2,
+                  scale: hasFocus ? 1 : 0.9,
                   child: AnimatedContainer(
                       decoration: BoxDecoration(
                         borderRadius: BorderRadius.circular(15),

--- a/lib/views/videoList.dart
+++ b/lib/views/videoList.dart
@@ -57,10 +57,10 @@ class VideoList extends StatelessWidget {
                       duration: animationDuration,
                       curve: Curves.easeInOutQuad,
                       child: Visibility(
-                        visible: _.videos.isNotEmpty,
+                        visible: _.items.isNotEmpty,
                         child: SmartRefresher(
                           controller: _.refreshController,
-                          enablePullDown: _.videoList.hasRefresh(),
+                          enablePullDown: _.itemList.hasRefresh(),
                           enablePullUp: false,
                           onRefresh: _.refreshVideos,
                           child: GridView.count(
@@ -70,7 +70,7 @@ class VideoList extends StatelessWidget {
                               crossAxisSpacing: 5,
                               mainAxisSpacing: 5,
                               childAspectRatio: getGridAspectRatio(context),
-                              children: (_.videos).map((v) => VideoListItem(key: ValueKey(v.videoId), video: v)).toList()),
+                              children: (_.items).map((v) => VideoListItem(key: ValueKey(v.videoId), video: v)).toList()),
                         ),
                       ),
                     ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.9.2+4007
+version: 1.10.0+4008
 
 environment:
   sdk: '>=3.0.0 <4.0.0'


### PR DESCRIPTION
TV: replace text fields to make navigation easier, user will have to click on the fileds to actually input text.
TV: Replace + / - button on settings and use remote left and right button to adjust subtitle size and search history limits fix #231
TV: Updated player to handle video queue (for playlist  and recommended videos) 
TV: Improvement on playlist original implementation from @Outlet7493  by adding a play button for the whole playlist
TV: Scroll to top when selecting the highest  item in the screen on channel, video and playlist views.



Text field unfocused:
![image](https://github.com/lamarios/clipious/assets/1192563/46198cfc-d6c4-435a-bcc2-0076d872ac32)

Focused:
![image](https://github.com/lamarios/clipious/assets/1192563/9677fcef-8740-4945-878a-09d152fcf87a)


Required a "Enter" / "OK" click to actually edit it:
![image](https://github.com/lamarios/clipious/assets/1192563/7d990849-fe9c-4e39-b29d-4f2097e2f3da)


Sounds silly but otherwise text fields are very hard to deal with when handling focus based navigation


Added playlist to channel / search
![image](https://github.com/lamarios/clipious/assets/1192563/714eaa7f-924d-429c-b616-5e1ffd1797c1)

Playlist view:
![image](https://github.com/lamarios/clipious/assets/1192563/09c6ee88-1f95-4058-bcea-fdee817817e0)

Updated player view:
![image](https://github.com/lamarios/clipious/assets/1192563/eb2b64d8-80c5-4e78-84f1-68d974e5332d)

That now has a queue and can handle many videos with skip to next / previous. 
For single videos, the queue will be the recommended videos.
![image](https://github.com/lamarios/clipious/assets/1192563/ce62c0c3-531f-4a54-8788-dcd8df162229)

