### PR TITLE
Fix unicode search suggestions

### DIFF
--- a/lib/service.dart
+++ b/lib/service.dart
@@ -368,14 +368,10 @@ class Service {
         SearchSuggestion.fromJson(handleResponse(response));
     if (search.suggestions.any((element) => element.contains(";"))) {
       search.suggestions = search.suggestions
-          .map((s) => s
-              .replaceAll(" ", "&#0032;")
-              .split(";")
-              .where((e) => e.isNotEmpty && e.startsWith("&#"))
-              .map(
-                  (e) => String.fromCharCode(int.parse(e.replaceAll("&#", ""))))
-              .toList()
-              .join(""))
+          .map((s) => s.replaceAll(" ", "&#32;").replaceAllMapped(
+          RegExp(r"&#\w*;"),
+              (m) => String.fromCharCode(
+              int.parse(m[0]!.replaceAll(RegExp(r"&#|;"), "")))))
           .toList();
     }
 

--- a/lib/service.dart
+++ b/lib/service.dart
@@ -369,9 +369,9 @@ class Service {
     if (search.suggestions.any((element) => element.contains(";"))) {
       search.suggestions = search.suggestions
           .map((s) => s.replaceAll(" ", "&#32;").replaceAllMapped(
-          RegExp(r"&#\w*;"),
+              RegExp(r"&#\w*;"),
               (m) => String.fromCharCode(
-              int.parse(m[0]!.replaceAll(RegExp(r"&#|;"), "")))))
+                  int.parse(m[0]!.replaceAll(RegExp(r"&#|;"), "")))))
           .toList();
     }
 


### PR DESCRIPTION
Fixes https://github.com/lamarios/clipious/issues/446 - apologies for letting this slip.

I have moved the search suggestions to regex based replacement instead which should harden the logic a bit and hopefully now catch all use cases...

`m[0]!` the non-null assertion should be guaranteed, as it will have had to match the regex pattern for the function to be called.

Invidious API produces a response like:
```
[
  "test",
  "&#351;",
  "&#351;test",
  "&#351;&#351;&#351;&#351;",
  "&#1072;&#1072;&#1085;&#1090; &#1082;&#1086;&#1085;&#1090;&#1072;&#1082;&#1090;",
  "&#1072;&#1072;&#1085;&#1090;(test)&#1082;&#1086;&#1085;&#1090;&#1072;&#1082;&#1090;",
  "&#351;ahane hayat&#305;m",
]
```
New code produced:
`(test, ş, ştest, şşşş, аант контакт, аант(test)контакт, şahane hayatım)`

Code was formatted using pre-commit hook.