### PR TITLE
Add share to video modal sheet and bug fix

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -96,6 +96,10 @@
       }
     }
   },
+  "share": "Share",
+  "@share": {
+    "description": "asking user if to share"
+  },
   "shareYoutubeLink": "Share YouTube link",
   "@shareYoutubeLink": {
     "description": "asking user to share youtube link"

--- a/lib/videos/states/add_to_playlist.dart
+++ b/lib/videos/states/add_to_playlist.dart
@@ -43,6 +43,8 @@ class AddToPlaylistCubit extends Cubit<AddToPlaylistController> {
     late List<Playlist> playlists;
     if (state.isLoggedIn) {
       playlists = await service.getUserPlaylists();
+    } else {
+      playlists = List.empty();
     }
     emit(state.copyWith(playlists: playlists, loading: false));
   }

--- a/lib/videos/views/components/video_modal_sheet.dart
+++ b/lib/videos/views/components/video_modal_sheet.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:invidious/player/states/player.dart';
+import 'package:invidious/utils.dart';
 import 'package:invidious/videos/models/base_video.dart';
 import 'package:invidious/videos/views/components/add_to_playlist_button.dart';
 import 'package:invidious/videos/views/components/download_modal_sheet.dart';
@@ -56,6 +57,11 @@ class VideoModalSheet extends StatelessWidget {
     DownloadModalSheet.showVideoModalSheet(context, video);
   }
 
+  void _showSharingSheet(BuildContext context) {
+    Navigator.of(context).pop();
+    showSharingSheet(context, video);
+  }
+
   @override
   Widget build(BuildContext context) {
     var locals = AppLocalizations.of(context)!;
@@ -107,6 +113,20 @@ class VideoModalSheet extends StatelessWidget {
                       onPressed: () => downloadVideo(context),
                       icon: const Icon(Icons.download)),
                   Text(locals.download)
+                ],
+              ),
+            ),
+            Padding(
+              padding: getDeviceType() == DeviceType.phone
+                  ? const EdgeInsets.only(top: 8.0)
+                  : const EdgeInsets.only(right: 16.0),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  IconButton.filledTonal(
+                      onPressed: () => _showSharingSheet(context),
+                      icon: const Icon(Icons.share)),
+                  Text(locals.share)
                 ],
               ),
             ),


### PR DESCRIPTION
Fixes https://github.com/lamarios/clipious/issues/457 - adds share button to sheet, padding is adjusted depending on device as on a phone it gets pushed beneath.

Phone:
![phone_sheet](https://github.com/lamarios/clipious/assets/122801553/d318e0bf-2c70-4e9e-bce8-5c69a7314739)

Tablet:
![tablet_sheet](https://github.com/lamarios/clipious/assets/122801553/bcbc7511-2ff9-41fd-8a5c-54d89e49107e)

Also fixed a bug where if the user is not logged in, the "Add to playlist" button will just infinitely load (as request for user playlists fails) so made it return an empty list so the user can click it, to then login if they want to.