### PR TITLE
remove audio switch for live videos

### DIFF
--- a/lib/player/views/components/mini_player_controls.dart
+++ b/lib/player/views/components/mini_player_controls.dart
@@ -102,12 +102,17 @@ class MiniPlayerControls extends StatelessWidget {
                   var cubit = context.read<SettingsCubit>();
                   var isAudio = context
                       .select((PlayerCubit value) => value.state.isAudio);
+
+                  var hasAudio = context.select((PlayerCubit value) =>
+                      !(value.state.currentlyPlaying?.liveNow ?? false));
+
                   return Row(
                     mainAxisAlignment: MainAxisAlignment.end,
                     children: [
                       Visibility(
                         // only for online videos
-                        visible: player.state.currentlyPlaying != null,
+                        visible:
+                            player.state.currentlyPlaying != null && hasAudio,
                         child: MultiValueSwitch(
                           left: Icons.ondemand_video,
                           right: Icons.audiotrack,

--- a/lib/videos/views/components/inner_view.dart
+++ b/lib/videos/views/components/inner_view.dart
@@ -37,6 +37,7 @@ class VideoInnerView extends StatelessWidget {
 
     var playButton = PlayButton(
       icon: restart ? Icons.refresh : null,
+      hasAudio: !(video.liveNow ?? false),
       onPressed: restart ? cubit.restartVideo : cubit.playVideo,
     );
     return Column(

--- a/lib/videos/views/components/inner_view_tablet.dart
+++ b/lib/videos/views/components/inner_view_tablet.dart
@@ -63,6 +63,7 @@ class VideoTabletInnerView extends StatelessWidget {
                     children: [
                       PlayButton(
                         icon: restart ? Icons.refresh : null,
+                        hasAudio: !(video.liveNow ?? false),
                         onPressed:
                             restart ? cubit.restartVideo : cubit.playVideo,
                       ),

--- a/lib/videos/views/components/play_button.dart
+++ b/lib/videos/views/components/play_button.dart
@@ -2,10 +2,12 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 
 class PlayButton extends StatelessWidget {
+  final bool hasAudio;
   final Function(bool isAudio) onPressed;
   final IconData? icon;
 
-  const PlayButton({super.key, required this.onPressed, this.icon});
+  const PlayButton(
+      {super.key, required this.onPressed, this.icon, this.hasAudio = true});
 
   @override
   Widget build(BuildContext context) {
@@ -13,23 +15,24 @@ class PlayButton extends StatelessWidget {
     return Stack(
       alignment: Alignment.center,
       children: [
-        Padding(
-          padding: const EdgeInsets.only(left: 100.0, top: 60),
-          child: IconButton(
-            onPressed: () {
-              onPressed(true);
-              AutoRouter.of(context).maybePop();
-            },
-            style: ButtonStyle(
-                backgroundColor: WidgetStateProperty.resolveWith(
-                    (states) => colorScheme.primary.withOpacity(1))),
-            icon: const Icon(
-              Icons.music_note,
-              size: 35,
+        if (hasAudio)
+          Padding(
+            padding: const EdgeInsets.only(left: 100.0, top: 60),
+            child: IconButton(
+              onPressed: () {
+                onPressed(true);
+                AutoRouter.of(context).maybePop();
+              },
+              style: ButtonStyle(
+                  backgroundColor: WidgetStateProperty.resolveWith(
+                      (states) => colorScheme.primary.withOpacity(1))),
+              icon: const Icon(
+                Icons.music_note,
+                size: 35,
+              ),
+              color: colorScheme.primaryContainer,
             ),
-            color: colorScheme.primaryContainer,
           ),
-        ),
         IconButton(
           onPressed: () {
             onPressed(false);

--- a/lib/videos/views/components/video_metrics.dart
+++ b/lib/videos/views/components/video_metrics.dart
@@ -103,7 +103,8 @@ class VideoMetrics extends StatelessWidget {
       }
 
       var date = video?.publishedText ?? '';
-      if (date.isNotEmpty || video?.liveNow == true) {
+      if ((date.isNotEmpty && !date.startsWith('0')) ||
+          video?.liveNow == true) {
         metrics.addAll([
           (video?.liveNow ?? false)
               ? Visibility(


### PR DESCRIPTION
fix #611

- [x] I have updated the version and build number accordingly

## Tests

These are things that are most likely to break when making changes unrelated changes

- [x] Can play video
- [x] New user experience, the set up wizard should show up if the user has no data

