### PR TITLE
fix issues with failed downloads that can't be removed.

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1382,5 +1382,6 @@
   "cancelSleepTimer": "Cancel sleep timer",
   "premieresIn": "Premieres in {formattedDuration}",
   "screenControls": "Screen controls",
-  "screenControlsExplanation": "When watching a video in full screen, Vertically dragging from the left or the right will adjust the brightness or volume respectively"
+  "screenControlsExplanation": "When watching a video in full screen, Vertically dragging from the left or the right will adjust the brightness or volume respectively",
+  "retry": "Retry"
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: clipious
-version: 1.22.3+4066
+version: 1.22.4+4067
 publish_to: none
 description: Client for invidious.
 environment: 


### PR DESCRIPTION
allow user to cancel an ongoing download
fix #542

- [x] I have updated the version and build number accordingly

## Tests

These are things that are most likely to break when making changes unrelated changes

- [x] Can play video
- [x] New user experience, the set up wizard should show up if the user has no data

